### PR TITLE
fix: 修复打包后的 chrome-sandbox 权限、串口原生模块加载与托盘图标

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -14,6 +14,14 @@ files:
   - '!{tsconfig.json,tsconfig.node.json,tsconfig.web.json}'
   - '!**/node_modules/{CHANGELOG.md,README.md,readme.md,test,__tests__,tests,powered-test,example,examples}'
   - '!**/node_modules/.bin'
+extraResources:
+  - from: build/icon.ico
+    to: icon.ico
+  - from: build/icon.png
+    to: icon.png
+asarUnpack:
+  - node_modules/serialport/**
+  - node_modules/@serialport/**
 win:
   executableName: SuperConnectX
 nsis:
@@ -44,7 +52,8 @@ linux:
   category: Utility
 appImage:
   artifactName: ${name}-${version}.${ext}
-npmRebuild: false
+afterPack: ./scripts/afterPack.js
+npmRebuild: true
 publish:
   provider: github
   owner: SuperStudio

--- a/package.json
+++ b/package.json
@@ -92,6 +92,10 @@
       {
         "from": "build/icon.icns",
         "to": "icon.icns"
+      },
+      {
+        "from": "build/icon.png",
+        "to": "icon.png"
       }
     ],
     "win": {

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -1,0 +1,10 @@
+const fs = require('fs')
+const path = require('path')
+
+module.exports = async function (context) {
+  const sandbox = path.join(context.appOutDir, 'chrome-sandbox')
+  if (fs.existsSync(sandbox)) {
+    fs.chmodSync(sandbox, 0o4755)
+    console.log('afterPack: chrome-sandbox permissions set to 4755')
+  }
+}


### PR DESCRIPTION
## 问题

Linux AppImage 安装/启动后存在三个打包相关问题：

1. **chrome-sandbox 权限错误**：启动报 `The SUID sandbox helper binary was found, but is not configured correctly`，需要手动 chmod 4755 才能运行
2. **串口枚举失败**：serialport 原生 `.node` 模块被打进 asar，无法从 asar 虚拟文件系统加载，打包后串口列表为空（开发环境正常）
3. **托盘图标缺失**：Linux 托盘从 resources 目录读取 icon.png，但未随包携带

## 改动

- **新增 `scripts/afterPack.js`**：打包后自动将 chrome-sandbox 置为 4755（SUID），AppImage 开箱即用
- **`asarUnpack` serialport / @serialport**：原生模块 unpack 到 asar.unpacked，运行时正常加载
- **`extraResources` 携带 icon.ico / icon.png**：托盘及运行时图标可用
- **`npmRebuild: true`**：构建时自动为 Electron ABI 重建 serialport 原生模块，避免 node 与 electron ABI 不匹配

以上均为打包配置修复，不影响开发环境行为；已在 fork 仓库的 CI 构建产物中验证。