### PR TITLE
feat: 添加 Ubuntu 24 兼容构建（Electron 35）

### DIFF
--- a/.github/workflows/ubuntu24.yml
+++ b/.github/workflows/ubuntu24.yml
@@ -1,0 +1,77 @@
+name: Ubuntu 24 Compatible Build
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-ubuntu24:
+    name: Linux (Ubuntu 24 compatible)
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm libarchive-tools
+
+      - name: Install Python setuptools
+        run: python3 -m pip install setuptools
+
+      - name: Install dependencies
+        run: npm install --ignore-scripts
+
+      - name: Downgrade Electron to 35 for Ubuntu 24 compatibility
+        run: npm install electron@35.7.5 --save-dev
+
+      - name: Remove problematic cpu-features
+        run: |
+          rm -rf node_modules/cpu-features
+          rm -rf node_modules/ssh2/node_modules/cpu-features
+
+      - name: Run tests
+        run: npm test
+
+      - name: Rebuild native modules
+        run: npx electron-builder install-app-deps
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build renderer and main
+        run: npx electron-vite build
+
+      - name: Build package (Linux Ubuntu 24)
+        run: npx electron-builder --linux AppImage deb --config electron-builder.yml --publish never
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rename Ubuntu 24 artifacts
+        run: |
+          cd release
+          for f in *.AppImage; do mv "$f" "${f%.AppImage}-ubuntu24.AppImage"; done
+          for f in *.deb; do mv "$f" "${f%.deb}-ubuntu24.deb"; done
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-ubuntu24-release
+          path: |
+            release/*-ubuntu24.AppImage
+            release/*-ubuntu24.deb
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/ubuntu24.yml
+++ b/.github/workflows/ubuntu24.yml
@@ -32,11 +32,13 @@ jobs:
       - name: Install Python setuptools
         run: python3 -m pip install setuptools
 
-      - name: Install dependencies
-        run: npm install --ignore-scripts
-
       - name: Downgrade Electron to 35 for Ubuntu 24 compatibility
-        run: npm install electron@35.7.5 --save-dev
+        # 仅更新 package.json 与 lock，随后用 npm ci 一次安装；
+        # 避免 node_modules 已存在时二次 npm install 触发 npm optional deps bug（丢失 @rollup/rollup-linux-x64-gnu）
+        run: npm install electron@35.7.5 --save-dev --package-lock-only
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
 
       - name: Remove problematic cpu-features
         run: |


### PR DESCRIPTION
## 背景

Ubuntu 24.04 上运行 Electron 38 构建的 Linux 包存在兼容问题，实测将 Electron 降级为 35 构建的包在 Ubuntu 24.04 上可正常运行。本 PR 添加一个独立的兼容构建流程，让 Ubuntu 24 用户有可用产物，同时不影响常规 Electron 38 包。

## 改动（仅新增 `ubuntu24.yml`，自包含，与其他流程无耦合）

- 在 `ubuntu-22.04` runner 上 `npm install electron@35.7.5 --save-dev` 降级后构建 AppImage + deb
- 产物统一加 `-ubuntu24` 后缀，与常规包区分，避免同名冲突
- 走完整验证流程（测试 → 类型检查 → 构建），保证降级后代码仍可用
- **仅上传 artifacts（保留 7 天），不触发 Release 发布**，不与现有发布流程产生竞争

## 说明

- 这是一个折中方案：如果后续有更根本的解决方式（例如升级 Electron 修复兼容、或调整运行参数），本流程可随时移除
- 若作者希望 Ubuntu 24 包随 Release 正式发布，可在 #214（两阶段发布结构）合并后将其纳入 release job 统一上传
- 已在 fork 仓库实际构建验证，产物在 Ubuntu 24.04 实机可用
