### PR TITLE
fix: 终端字体链按平台适配，修复 Linux 显示效果差

### DIFF
--- a/src/renderer/src/components/ComTerminal.vue
+++ b/src/renderer/src/components/ComTerminal.vue
@@ -171,6 +171,7 @@ import { useI18n } from 'vue-i18n'
 import { ElMessage } from 'element-plus'
 import UnifiedTerminal from './UnifiedTerminal.vue'
 import { useTerminal } from '../composables/useTerminal'
+import { getDefaultTerminalFont } from '../utils/FontDetector'
 
 const { t } = useI18n()
 
@@ -414,7 +415,7 @@ const loadComSettings = async () => {
       crcEnabled.value = settings.crcEnabled !== undefined ? settings.crcEnabled : true
       crcMethod.value = settings.crcMethod || 'CRC-16/MODBUS'
       terminal.fontSize.value = settings.fontSize !== undefined ? settings.fontSize : 14
-      terminal.fontFamily.value = settings.fontFamily || 'Fira Code'
+      terminal.fontFamily.value = settings.fontFamily || getDefaultTerminalFont()
       const savedInput = settings.commandInput || ''
 
       unifiedTerminalRef.value?.setHexDisplayMode?.(hexDisplayMode.value)
@@ -785,7 +786,7 @@ onUnmounted(() => {
   flex-direction: column;
   background: var(--com-terminal-bg);
   color: var(--com-terminal-color);
-  font-family: 'Fira Code', 'Consolas', monospace;
+  font-family: 'Fira Code', 'Consolas', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   overflow: hidden;
 }
 

--- a/src/renderer/src/components/CommandEditor.vue
+++ b/src/renderer/src/components/CommandEditor.vue
@@ -910,7 +910,7 @@ onBeforeUnmount(() => {
 
 .command-table .el-table :deep(.cell-command .el-input__inner) {
   color: var(--cmdeditor-command-color);
-  font-family: 'Consolas', 'Monaco', monospace;
+  font-family: 'Consolas', 'Monaco', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
 }
 
 .command-table .el-table :deep(.cell-command .el-input__inner:focus) {
@@ -928,7 +928,7 @@ onBeforeUnmount(() => {
 }
 
 .cmd-delay {
-  font-family: 'Consolas', 'Monaco', monospace;
+  font-family: 'Consolas', 'Monaco', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   color: var(--cmdeditor-seqnum-color);
 }
 
@@ -943,7 +943,7 @@ onBeforeUnmount(() => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: 'Consolas', 'Monaco', monospace;
+  font-family: 'Consolas', 'Monaco', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   color: var(--cmdeditor-command-color);
   background: var(--cmdeditor-command-bg);
   padding: 2px 8px;

--- a/src/renderer/src/components/CustomTitleBar.vue
+++ b/src/renderer/src/components/CustomTitleBar.vue
@@ -256,7 +256,7 @@
 import { ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
 import { ElMessageBox } from 'element-plus'
 import { useI18n } from 'vue-i18n'
-import { getSystemFonts, formatFontName } from '../utils/FontDetector'
+import { getSystemFonts, formatFontName, getDefaultTerminalFont } from '../utils/FontDetector'
 import ExportDialog from './ExportDialog.vue'
 
 const { t } = useI18n()
@@ -270,7 +270,7 @@ const showHelpMenu = ref(false)
 const showFontSubmenu = ref(false)
 const fontsLoaded = ref(false)
 const systemFonts = ref<string[]>([])
-const currentFontFamily = ref('Fira Code') // 当前活动的字体
+const currentFontFamily = ref(getDefaultTerminalFont()) // 当前活动的字体
 
 // ---- 皮肤切换 ----
 const showThemePanel = ref(false)
@@ -314,7 +314,7 @@ const props = defineProps({
   },
   currentFont: {
     type: String,
-    default: 'Fira Code'
+    default: () => getDefaultTerminalFont()
   },
   wordWrap: {
     type: Boolean,

--- a/src/renderer/src/components/ShortcutsPage.vue
+++ b/src/renderer/src/components/ShortcutsPage.vue
@@ -634,7 +634,7 @@ const clearSearch = () => {
   background: var(--shortcuts-table-border);
   color: var(--shortcuts-action-name);
   font-size: 12px;
-  font-family: 'Consolas', 'Monaco', monospace;
+  font-family: 'Consolas', 'Monaco', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   border-radius: 4px;
   border: 1px solid var(--key-badge-border);
   white-space: nowrap;

--- a/src/renderer/src/components/SyntaxHighlightPage.vue
+++ b/src/renderer/src/components/SyntaxHighlightPage.vue
@@ -145,6 +145,7 @@ import { ElMessage, ElMessageBox } from 'element-plus'
 import * as monaco from 'monaco-editor'
 import { Plus, Delete } from '@element-plus/icons-vue'
 import { getMonacoTheme } from '../utils/MonacoTheme'
+import { getDefaultTerminalFont } from '../utils/FontDetector'
 
 const { t } = useI18n()
 
@@ -476,7 +477,7 @@ const initPreviewEditor = () => {
     links: false,
     wordWrap: 'on',
     fontSize: 13,
-    fontFamily: "'Fira Code', 'Consolas', monospace"
+    fontFamily: getDefaultTerminalFont()
   })
 
   // 监听文本变化，同步到 activeGroup.previewText

--- a/src/renderer/src/components/TelnetTerminal.vue
+++ b/src/renderer/src/components/TelnetTerminal.vue
@@ -414,7 +414,7 @@ onMounted(() => {
   flex-direction: column;
   background: var(--bg-primary);
   color: var(--text-white);
-  font-family: 'Fira Code', 'Consolas', monospace;
+  font-family: 'Fira Code', 'Consolas', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   border-radius: 0px;
   overflow: hidden;
 }

--- a/src/renderer/src/components/UnifiedTerminal.vue
+++ b/src/renderer/src/components/UnifiedTerminal.vue
@@ -189,6 +189,7 @@ import TerminalControl from './TerminalControl.vue'
 import { parseAnsiToSegments } from '../utils/AnsiParser'
 import { AnsiDecorationManager } from '../utils/AnsiDecorationManager'
 import { getMonacoTheme } from '../utils/MonacoTheme'
+import { getDefaultTerminalFont } from '../utils/FontDetector'
 
 const maxClearSizeMB = ref(30)
 
@@ -282,7 +283,7 @@ const hexMode = ref(false) // 是否为HEX发送模式
 const hexDisplayMode = ref(false) // 是否为HEX显示模式（接收端）
 const showTimestamp = ref(true) // 是否显示时间戳
 const fontSize = ref(14) // 终端字体大小
-const fontFamily = ref('Consolas') // 终端字体系列
+const fontFamily = ref(getDefaultTerminalFont()) // 终端字体系列（平台感知默认值）
 const MIN_FONT_SIZE = 8
 const MAX_FONT_SIZE = 30
 
@@ -1473,7 +1474,7 @@ watch(activeSyntaxGroupId, async (newVal, oldVal) => {
   flex-direction: column;
   background: var(--terminal-bg);
   color: var(--text-white);
-  font-family: 'Fira Code', 'Consolas', monospace;
+  font-family: 'Fira Code', 'Consolas', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   overflow: hidden;
 }
 
@@ -1787,7 +1788,7 @@ watch(activeSyntaxGroupId, async (newVal, oldVal) => {
   cursor: pointer;
   color: var(--history-item-color);
   font-size: 12px;
-  font-family: 'Fira Code', 'Consolas', monospace;
+  font-family: 'Fira Code', 'Consolas', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1949,7 +1950,7 @@ watch(activeSyntaxGroupId, async (newVal, oldVal) => {
   display: flex;
   align-items: center;
   gap: 6px;
-  font-family: 'Fira Code', 'Consolas', monospace;
+  font-family: 'Fira Code', 'Consolas', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', monospace;
   font-size: 12px;
 }
 

--- a/src/renderer/src/composables/app/useFontManager.ts
+++ b/src/renderer/src/composables/app/useFontManager.ts
@@ -3,13 +3,14 @@
  * 管理：当前活动字体获取、字体/字体大小变更
  */
 import { ref, watch, nextTick } from 'vue'
+import { getDefaultTerminalFont } from '../../utils/FontDetector'
 
 export function useFontManager(
   activeTabId: any,
   comTerminalRefs: Record<string, any>,
   telnetTerminalRefs: Record<string, any>
 ) {
-  const currentFont = ref('Fira Code')
+  const currentFont = ref(getDefaultTerminalFont())
 
   const updateCurrentFont = (tabId: string, retries = 5) => {
     const tryGetFont = () => {
@@ -32,7 +33,7 @@ export function useFontManager(
       if (retryCount < retries) {
         setTimeout(retry, 100)
       } else {
-        currentFont.value = 'Fira Code'
+        currentFont.value = getDefaultTerminalFont()
       }
     }
     setTimeout(retry, 100)

--- a/src/renderer/src/composables/useTerminal.ts
+++ b/src/renderer/src/composables/useTerminal.ts
@@ -1,6 +1,7 @@
 import { ref, watch, onUnmounted, type Ref } from 'vue'
 import { ElMessage } from 'element-plus'
 import { useI18n } from 'vue-i18n'
+import { getDefaultTerminalFont } from '../utils/FontDetector'
 
 export interface TerminalConnection {
   id: string | number
@@ -74,7 +75,7 @@ export function useTerminal(options: UseTerminalOptions): UseTerminalReturn {
 
   // 状态
   const fontSize = ref(14)
-  const fontFamily = ref('Fira Code')
+  const fontFamily = ref(getDefaultTerminalFont())
   const showTimestamp = ref(true)
   let totalRxSize = 0
   let totalTxSize = 0

--- a/src/renderer/src/utils/FontDetector.ts
+++ b/src/renderer/src/utils/FontDetector.ts
@@ -18,6 +18,22 @@ const waitForPageVisible = () => {
   })
 }
 
+/**
+ * 平台感知的终端默认等宽字体链。
+ * Fira Code 全平台优先（用户自行安装则生效），其后按平台回退到系统自带等宽字体，
+ * 避免 Linux 上 Fira Code/Consolas 均不存在时浏览器随意 fallback 导致中西文宽度失调。
+ */
+export const getDefaultTerminalFont = (userAgent?: string): string => {
+  const ua = userAgent ?? navigator.userAgent
+  if (ua.includes('Windows')) {
+    return "'Fira Code', 'Cascadia Mono', 'Consolas', monospace"
+  }
+  if (ua.includes('Mac')) {
+    return "'Fira Code', 'Menlo', 'Monaco', monospace"
+  }
+  return "'Fira Code', 'Ubuntu Mono', 'Noto Sans Mono CJK SC', 'WenQuanYi Micro Hei Mono', 'DejaVu Sans Mono', monospace"
+}
+
 export const formatFontName = (fontName: string) => {
   const fontNameMap: Record<string, string> = {
     SimSun: '宋体',

--- a/tests/unit/FontDetector.test.ts
+++ b/tests/unit/FontDetector.test.ts
@@ -1,7 +1,47 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { formatFontName, getSystemFonts } from '../../src/renderer/src/utils/FontDetector'
+import {
+  formatFontName,
+  getSystemFonts,
+  getDefaultTerminalFont
+} from '../../src/renderer/src/utils/FontDetector'
 
 describe('FontDetector', () => {
+  describe('getDefaultTerminalFont', () => {
+    it('Windows 返回 Fira Code/Cascadia/Consolas 链', () => {
+      const ua =
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/130.0.0.0 Electron/33.0.0'
+      const font = getDefaultTerminalFont(ua)
+      expect(font).toContain('Fira Code')
+      expect(font).toContain('Cascadia Mono')
+      expect(font).toContain('Consolas')
+      expect(font).toContain('monospace')
+    })
+
+    it('macOS 返回 Fira Code/Menlo/Monaco 链', () => {
+      const ua =
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/130.0.0.0 Electron/33.0.0'
+      const font = getDefaultTerminalFont(ua)
+      expect(font).toContain('Fira Code')
+      expect(font).toContain('Menlo')
+      expect(font).toContain('Monaco')
+      expect(font).toContain('monospace')
+    })
+
+    it('Linux 返回 Fira Code/Ubuntu Mono/Noto CJK 链', () => {
+      const ua =
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/130.0.0.0 Electron/33.0.0'
+      const font = getDefaultTerminalFont(ua)
+      expect(font).toContain('Fira Code')
+      expect(font).toContain('Ubuntu Mono')
+      expect(font).toContain('Noto Sans Mono CJK SC')
+      expect(font).toContain('DejaVu Sans Mono')
+      expect(font).toContain('monospace')
+      // Linux 链不应包含 Windows/macOS 专有字体
+      expect(font).not.toContain('Consolas')
+      expect(font).not.toContain('Menlo')
+    })
+  })
+
   describe('formatFontName', () => {
     it('映射已知字体名称', () => {
       expect(formatFontName('SimSun')).toBe('宋体')


### PR DESCRIPTION
## 背景

终端默认字体链为 `Fira Code` / `Consolas` 硬编码（6 处运行时默认值 + 8 处 CSS 字体链）。Fira Code 是第三方字体、Consolas 是 Windows 字体、Monaco 是 macOS 字体——在 Linux 发行版（实测 Ubuntu 24.04）上全部未安装，浏览器被迫随意 fallback：拉丁字符落到 DejaVu Sans Mono、中文再落到非等宽 CJK 字体，中西文宽度不成 2:1，表现为字符对不齐、光标漂移，终端显示效果差。

## 改动

- **`FontDetector.ts` 新增 `getDefaultTerminalFont()`**：Fira Code 全平台优先（用户安装则生效），其后按平台回退到系统自带等宽字体：
  - Windows: Cascadia Mono → Consolas
  - macOS: Menlo → Monaco
  - Linux: Ubuntu Mono → Noto Sans Mono CJK SC → 文泉驿等宽微米黑 → DejaVu Sans Mono
- **6 处运行时默认值统一接入**：`UnifiedTerminal.vue`（原 Consolas）、`useTerminal.ts`、`ComTerminal.vue`、`useFontManager.ts`、`CustomTitleBar.vue`（含 prop default）、`SyntaxHighlightPage.vue`
- **8 处 CSS 字体链**追加 `'Ubuntu Mono', 'Noto Sans Mono CJK SC'`（命令编辑器、终端输入框等）
- 新增 3 个平台分支单元测试

## 验证

- **Ubuntu 24.04 实测**：字体链命中系统自带 Ubuntu Mono，中西文严格 2:1 对齐
- `npm run typecheck` 通过；单元测试 12/12 通过（含新增 3 个平台分支用例）
- **Windows/macOS 行为不变**：链首仍是 Fira Code，原默认 Consolas/Menlo/Monaco 仍在链中兜底
- 用户已在设置中保存的字体选择不受影响（存储值优先于默认链）