### PR TITLE
ci: 统一发布产物命名并按安装包拆分 CI artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,34 +21,17 @@ jobs:
           - name: Windows
             os: windows-2022
             builder-target: --win nsis zip
-            artifact-name: windows-release
-            artifact-path: |
-              release/*.exe
-              release/*.zip
-              release/*.yml
-              release/*.blockmap
           - name: Linux
             os: ubuntu-22.04
             builder-target: --linux
-            artifact-name: linux-release
-            artifact-path: |
-              release/*.AppImage
-              release/*.snap
-              release/*.deb
-              release/*.yml
-              release/*.blockmap
           - name: macOS (Apple Silicon)
             os: macos-14
             builder-target: --mac --arm64
             mac-arch: arm64
-            artifact-name: macos-arm64
-            artifact-path: release/*arm64.dmg
           - name: macOS (Intel)
             os: macos-15-intel
             builder-target: --mac --x64
             mac-arch: x64
-            artifact-name: macos-x64
-            artifact-path: release/*x64.dmg
 
     steps:
       - name: Checkout
@@ -127,11 +110,63 @@ jobs:
             exit 1
           fi
 
-      - name: Upload artifacts
+      # 每个安装包一个独立 artifact，下载下来就是单独的包
+      - name: Upload Windows installer
+        if: runner.os == 'Windows'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.artifact-name }}
-          path: ${{ matrix.artifact-path }}
+          name: windows-x64-setup
+          path: |
+            release/*-setup.exe
+            release/*-setup.exe.blockmap
+            release/latest.yml
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload Windows portable
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-x64-portable
+          path: release/*-portable.zip
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload Linux AppImage
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64-appimage
+          path: |
+            release/*.AppImage
+            release/latest-linux.yml
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload Linux deb
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64-deb
+          path: release/*.deb
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload Linux snap
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-x64-snap
+          path: release/*.snap
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload macOS dmg
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.mac-arch }}-dmg
+          path: release/*${{ matrix.mac-arch }}.dmg
           retention-days: 7
           if-no-files-found: error
 
@@ -191,12 +226,18 @@ jobs:
           for f in *.AppImage; do mv "$f" "${f%.AppImage}-ubuntu24.AppImage"; done
           for f in *.deb; do mv "$f" "${f%.deb}-ubuntu24.deb"; done
 
-      - name: Upload artifacts
+      - name: Upload Ubuntu 24 AppImage
         uses: actions/upload-artifact@v4
         with:
-          name: linux-ubuntu24-release
-          path: |
-            release/*-ubuntu24.AppImage
-            release/*-ubuntu24.deb
+          name: linux-ubuntu24-x64-appimage
+          path: release/*-ubuntu24.AppImage
+          retention-days: 7
+          if-no-files-found: error
+
+      - name: Upload Ubuntu 24 deb
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-ubuntu24-x64-deb
+          path: release/*-ubuntu24.deb
           retention-days: 7
           if-no-files-found: error

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -26,8 +26,10 @@ asarUnpack:
   - node_modules/@serialport/**
 win:
   executableName: SuperConnectX
+  # 平台级命名作用于 zip 便携包；nsis 安装包由下方 nsis.artifactName 覆盖
+  artifactName: ${name}-${version}-windows-x64-portable.${ext}
 nsis:
-  artifactName: ${name}.Setup.${version}.${ext}
+  artifactName: ${name}-${version}-windows-x64-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -44,7 +46,7 @@ mac:
     - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
   notarize: false
 dmg:
-  artifactName: ${name}-mac-${arch}.${ext}
+  artifactName: ${name}-${version}-macos-${arch}.${ext}
 linux:
   target:
     - AppImage
@@ -53,7 +55,11 @@ linux:
   maintainer: SuperStudio
   category: Utility
 appImage:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${name}-${version}-linux-x64.${ext}
+deb:
+  artifactName: ${name}-${version}-linux-x64.${ext}
+snap:
+  artifactName: ${name}-${version}-linux-x64.${ext}
 afterPack: ./scripts/afterPack.js
 npmRebuild: true
 publish:


### PR DESCRIPTION
## 背景

GitHub Release 资产只能按文件名字母序排列，当前产物命名是三套风格混用：

- 点号：`superconnectx.Setup.1.2.5.exe`
- 下划线：`superconnectx_1.2.5_amd64.deb`
- 横线：`superconnectx-1.2.5-win.zip`

ASCII 排序 `-` < `.` < `_`，导致同一系统的文件在 Release 页面被拆散（win.zip 夹在 AppImage 中间、Setup.exe 掉到最后）。

另外 dmg 命名不含版本号（`superconnectx-mac-arm64.dmg`），release workflow 生成 `latest-mac.yml` 时从文件名提取不到版本号，一直回退为 `0.0.0`，macOS 自动更新的版本检测实际失效。

## 改动

**1. electron-builder.yml：统一命名 `${name}-${version}-<系统>-<架构>[-变体].${ext}`**

| 产物 | 新命名 |
|---|---|
| nsis | `...-windows-x64-setup.exe` |
| zip 便携包 | `...-windows-x64-portable.zip`（经 win 平台级 artifactName，nsis 自身配置覆盖） |
| dmg | `...-macos-{arm64,x64}.dmg`（补版本号） |
| AppImage / deb / snap | `...-linux-x64.*` |
| ubuntu24 兼容版 | 沿用现有重命名步骤，自动变为 `...-linux-x64-ubuntu24.*` |

**2. ci.yml：CI 产物按安装包拆分为独立 artifact**

原来是"一个平台一个大 zip、所有文件混在一起"，现在 9 个独立 artifact（`windows-x64-setup`、`windows-x64-portable`、`linux-x64-appimage/deb/snap`、`linux-ubuntu24-x64-appimage/deb`、`macos-arm64/x64-dmg`），下载解压即为单独的包；`latest.yml` 随 Windows 安装包、`latest-linux.yml` 随 AppImage。

## 兼容性

- `latest*.yml` 由 electron-builder 构建时生成，url 自动跟随新文件名，自动更新不受影响
- workflow 的 macOS 产物校验 glob、ubuntu24 重命名步骤均兼容新命名，无需改动
- 已完整验证：CI 9 个 artifact 全部构建成功，`latest-mac.yml` 版本号恢复正确（1.2.5）