### PR TITLE
feat: 串口热插拔自动刷新 + COM 分组常驻显示

### DIFF
--- a/src/main/ipc/IpcSerialPort.ts
+++ b/src/main/ipc/IpcSerialPort.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import { SerialPort } from 'serialport'
-import { execSync } from 'child_process'
+import { execFile } from 'child_process'
 import logger from './IpcAppLogger'
 
 /** 主进程窗口集合（仅需 mainWindow.webContents.send 能力） */
@@ -69,7 +69,7 @@ export default class IpcSerialPort {
       // HKLM\HARDWARE\DEVICEMAP\SERIALCOMM but have no SetupAPI device node,
       // so SerialPort.list() won't pick them up.
       if (platform === 'win32') {
-        const registryPorts = this.getWindowsRegistryPorts(logResult)
+        const registryPorts = await this.getWindowsRegistryPorts(logResult)
         const existingPaths = new Set(filtered.map((p) => (p.path || '').toUpperCase()))
         for (const regPort of registryPorts) {
           if (!existingPaths.has(regPort.path.toUpperCase())) {
@@ -104,26 +104,32 @@ export default class IpcSerialPort {
    * Windows: read COM port mappings from the registry.
    * Returns ports that serialport's SetupAPI enumeration might miss
    * (e.g. com0com virtual ports that only have a registry entry).
+   * 异步执行（execFile）：热插拔轮询每 2s 触发一次，同步 execSync 会阻塞主进程
    */
-  private getWindowsRegistryPorts(logResult: boolean = true): { path: string }[] {
-    try {
-      const regOutput = execSync(
-        'reg query "HKLM\\HARDWARE\\DEVICEMAP\\SERIALCOMM" 2>&1',
-        { encoding: 'utf-8', timeout: 3000 }
+  private getWindowsRegistryPorts(logResult: boolean = true): Promise<{ path: string }[]> {
+    return new Promise((resolve) => {
+      execFile(
+        'reg',
+        ['query', 'HKLM\\HARDWARE\\DEVICEMAP\\SERIALCOMM'],
+        { encoding: 'utf-8', timeout: 3000, windowsHide: true },
+        (error, stdout) => {
+          if (error) {
+            if (logResult) logger.info('registry supplement: failed to read SERIALCOMM')
+            resolve([])
+            return
+          }
+          const ports: { path: string }[] = []
+          // Each line looks like: "    \\Device\\com0com10    REG_SZ    COM55"
+          const re = /REG_SZ\s+(COM\d+)/gi
+          let match: RegExpExecArray | null
+          while ((match = re.exec(stdout)) !== null) {
+            ports.push({ path: match[1] })
+          }
+          if (logResult) logger.info(`registry supplement: found ${ports.length} ports from SERIALCOMM`)
+          resolve(ports)
+        }
       )
-      const ports: { path: string }[] = []
-      // Each line looks like: "    \\Device\\com0com10    REG_SZ    COM55"
-      const re = /REG_SZ\s+(COM\d+)/gi
-      let match: RegExpExecArray | null
-      while ((match = re.exec(regOutput)) !== null) {
-        ports.push({ path: match[1] })
-      }
-      if (logResult) logger.info(`registry supplement: found ${ports.length} ports from SERIALCOMM`)
-      return ports
-    } catch {
-      if (logResult) logger.info('registry supplement: failed to read SERIALCOMM')
-      return []
-    }
+    })
   }
 
   /**

--- a/src/main/ipc/IpcSerialPort.ts
+++ b/src/main/ipc/IpcSerialPort.ts
@@ -3,8 +3,17 @@ import { SerialPort } from 'serialport'
 import { execSync } from 'child_process'
 import logger from './IpcAppLogger'
 
+/** 主进程窗口集合（仅需 mainWindow.webContents.send 能力） */
+interface WindowsRef {
+  mainWindow?: { webContents?: { send: (channel: string, ...args: unknown[]) => void } } | null
+}
+
 export default class IpcSerialPort {
   private static sInstance: IpcSerialPort
+  private windows: WindowsRef | null = null
+  private hotplugTimer: NodeJS.Timeout | null = null
+  private lastPortSignature = ''
+  private readonly HOTPLUG_INTERVAL_MS = 2000
 
   constructor() {}
 
@@ -15,10 +24,10 @@ export default class IpcSerialPort {
     return IpcSerialPort.sInstance
   }
 
-  async listSerialPorts(): Promise<object[]> {
+  async listSerialPorts(logResult: boolean = true): Promise<object[]> {
     try {
       const ports = await SerialPort.list()
-      logger.info(`serialport.list() returned ${ports.length} ports`)
+      if (logResult) logger.info(`serialport.list() returned ${ports.length} ports`)
 
       const platform = process.platform
 
@@ -60,7 +69,7 @@ export default class IpcSerialPort {
       // HKLM\HARDWARE\DEVICEMAP\SERIALCOMM but have no SetupAPI device node,
       // so SerialPort.list() won't pick them up.
       if (platform === 'win32') {
-        const registryPorts = this.getWindowsRegistryPorts()
+        const registryPorts = this.getWindowsRegistryPorts(logResult)
         const existingPaths = new Set(filtered.map((p) => (p.path || '').toUpperCase()))
         for (const regPort of registryPorts) {
           if (!existingPaths.has(regPort.path.toUpperCase())) {
@@ -74,7 +83,7 @@ export default class IpcSerialPort {
         (port, index, allPorts) => allPorts.findIndex((candidate) => candidate.path === port.path) === index
       )
 
-      logger.info(`filtered to ${uniquePorts.length} serial ports`)
+      if (logResult) logger.info(`filtered to ${uniquePorts.length} serial ports`)
       return uniquePorts.map((port) => ({
         path: port.path,
         manufacturer: port.manufacturer,
@@ -96,7 +105,7 @@ export default class IpcSerialPort {
    * Returns ports that serialport's SetupAPI enumeration might miss
    * (e.g. com0com virtual ports that only have a registry entry).
    */
-  private getWindowsRegistryPorts(): { path: string }[] {
+  private getWindowsRegistryPorts(logResult: boolean = true): { path: string }[] {
     try {
       const regOutput = execSync(
         'reg query "HKLM\\HARDWARE\\DEVICEMAP\\SERIALCOMM" 2>&1',
@@ -109,18 +118,68 @@ export default class IpcSerialPort {
       while ((match = re.exec(regOutput)) !== null) {
         ports.push({ path: match[1] })
       }
-      logger.info(`registry supplement: found ${ports.length} ports from SERIALCOMM`)
+      if (logResult) logger.info(`registry supplement: found ${ports.length} ports from SERIALCOMM`)
       return ports
     } catch {
-      logger.info('registry supplement: failed to read SERIALCOMM')
+      if (logResult) logger.info('registry supplement: failed to read SERIALCOMM')
       return []
     }
   }
 
-  init(_logger: any, _windows: any): void {
+  /**
+   * 启动串口热插拔监听：轮询串口列表，仅在列表变化时通知渲染进程刷新。
+   * 采用轮询而非原生事件（WM_DEVICECHANGE / udev / IOKit），无需额外原生依赖，跨平台行为一致。
+   */
+  startHotplugWatch(): void {
+    if (this.hotplugTimer) return
+
+    // 先记录基线：渲染进程启动时会自行加载一次列表，避免启动后立即触发一次无谓刷新
+    this.listSerialPorts(false)
+      .then((ports) => {
+        this.lastPortSignature = this.buildPortSignature(ports)
+      })
+      .catch(() => {})
+
+    this.hotplugTimer = setInterval(() => {
+      this.checkPortChanges().catch(() => {})
+    }, this.HOTPLUG_INTERVAL_MS)
+    this.hotplugTimer.unref?.() // 不阻止进程退出
+    logger.info('serial port hotplug watch started')
+  }
+
+  stopHotplugWatch(): void {
+    if (this.hotplugTimer) {
+      clearInterval(this.hotplugTimer)
+      this.hotplugTimer = null
+    }
+  }
+
+  private buildPortSignature(ports: object[]): string {
+    return ports
+      .map((p) => (p as { path?: string }).path || '')
+      .sort()
+      .join('|')
+  }
+
+  private async checkPortChanges(): Promise<void> {
+    const ports = await this.listSerialPorts(false)
+    const signature = this.buildPortSignature(ports)
+    if (signature === this.lastPortSignature) return
+
+    const oldSignature = this.lastPortSignature
+    this.lastPortSignature = signature
+    logger.info(`serial ports changed: [${oldSignature}] -> [${signature}]`)
+    this.windows?.mainWindow?.webContents?.send('on-serial-ports-changed', ports)
+  }
+
+  init(_logger: unknown, windows: WindowsRef): void {
+    this.windows = windows
+
     ipcMain.handle('list-serial-ports', async () => {
       return await this.listSerialPorts()
     })
+
+    this.startHotplugWatch()
 
     logger.info(`init IpcSerialPort done`)
   }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -91,6 +91,7 @@ declare global {
       copyLogFile: (sessionId: string, destPath: string) => Promise<{ success: boolean; message?: string }>
       rotateLogFile: (sessionId: string) => Promise<{ success: boolean; message?: string; oldFileName?: string; newFileName?: string }>
       listSerialPorts: () => Promise<SerialPortInfo[]>
+      onSerialPortsChanged: (callback: (ports: SerialPortInfo[]) => void) => () => void
       writeToLog: (sessionId: string, content: string) => Promise<any>
     }
     windowApi: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -93,6 +93,11 @@ contextBridge.exposeInMainWorld('connectApi', {
   copyLogFile: (sessionId: string, destPath: string) => ipcRenderer.invoke('copy-log-file', { sessionId, destPath }),
   rotateLogFile: (sessionId: string) => ipcRenderer.invoke('rotate-log-file', sessionId),
   listSerialPorts: () => ipcRenderer.invoke('list-serial-ports'),
+  onSerialPortsChanged: (callback: (ports: { path: string }[]) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, ports: { path: string }[]): void => callback(ports)
+    ipcRenderer.on('on-serial-ports-changed', listener)
+    return () => ipcRenderer.removeListener('on-serial-ports-changed', listener)
+  },
   writeToLog: (sessionId: string, content: string) => ipcRenderer.invoke('write-to-log', { sessionId, content })
 })
 

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -311,7 +311,7 @@ const {
   showConnectionList, sidebarWidth, serialPortExpanded, showPortType,
   connectionGroupExpanded, filteredSerialPorts, connectionGroups,
   handleSearch, loadConnections, loadSerialPorts, loadSidebarState,
-  toggleConnectionList
+  handleSerialPortsChanged, toggleConnectionList
 } = useConnectionSidebar()
 
 // ---- Tab Manager ----
@@ -1094,6 +1094,9 @@ onMounted(() => {
   window.connectApi.onLogSplit((data: { connId: string; oldFileName: string; newFileName: string }) => {
     handleLogSplit(data)
   })
+
+  // 串口热插拔：插入/拔出时自动刷新侧边栏串口列表
+  window.connectApi.onSerialPortsChanged(handleSerialPortsChanged)
 
   window.addEventListener('terminal-text-cleared', handleTerminalTextCleared)
   window.addEventListener('auto-scroll-toast', handleAutoScrollToast)

--- a/src/renderer/src/components/app/ConnectionSidebar.vue
+++ b/src/renderer/src/components/app/ConnectionSidebar.vue
@@ -12,8 +12,8 @@
       <!-- 可滚动区域：连接分组列表 -->
       <div class="connection-list-scroll">
         <div class="connection-groups">
-          <!-- 串口分组 -->
-          <div class="connection-group" v-if="serialPorts.length > 0">
+          <!-- 串口分组（常驻显示：无串口时保留刷新入口和空态提示） -->
+          <div class="connection-group">
             <div class="section-header" @click="$emit('update:serialPortExpanded', !serialPortExpanded)">
               <span class="section-title">
                 <el-icon class="expand-icon" :class="{ collapsed: !serialPortExpanded }"><ArrowRight /></el-icon>

--- a/src/renderer/src/composables/app/useConnectionSidebar.ts
+++ b/src/renderer/src/composables/app/useConnectionSidebar.ts
@@ -98,6 +98,14 @@ export function useConnectionSidebar() {
     }
   }
 
+  // 串口热插拔：主进程轮询检测到列表变化时整体替换（变化频率低，直接全量替换即可）
+  const handleSerialPortsChanged = (ports: SerialPortInfo[]): void => {
+    ports.forEach((port) => {
+      port.type = parseSerialPortType(port)
+    })
+    serialPorts.value = ports
+  }
+
   // 侧边栏状态持久化
   const loadSidebarState = async () => {
     try {
@@ -169,6 +177,7 @@ export function useConnectionSidebar() {
     handleSearch,
     loadConnections,
     loadSerialPorts,
+    handleSerialPortsChanged,
     loadSidebarState,
     saveSidebarState,
     toggleConnectionList,

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -73,6 +73,7 @@ interface ConnectApi {
   copyLogFile: (sessionId: string, destPath: string) => Promise<any>
   rotateLogFile: (sessionId: string) => Promise<any>
   listSerialPorts: () => Promise<any[]>
+  onSerialPortsChanged: (callback: (ports: any[]) => void) => () => void
   writeToLog: (sessionId: string, content: string) => Promise<any>
 }
 

--- a/src/renderer/src/locales/lang/en-US.json
+++ b/src/renderer/src/locales/lang/en-US.json
@@ -220,7 +220,7 @@
   "sidebar": {
     "newConnection": "New Connection",
     "searchPlaceholder": "Search...",
-    "noPorts": "No matching ports",
+    "noPorts": "No serial ports",
     "noConnections": "No matching connections",
     "address": "Address",
     "user": "User",

--- a/src/renderer/src/locales/lang/zh-CN.json
+++ b/src/renderer/src/locales/lang/zh-CN.json
@@ -220,7 +220,7 @@
   "sidebar": {
     "newConnection": "新建连接",
     "searchPlaceholder": "搜索...",
-    "noPorts": "无匹配串口",
+    "noPorts": "暂无串口",
     "noConnections": "无匹配连接",
     "address": "地址",
     "user": "用户",

--- a/tests/unit/IpcSerialPort.test.ts
+++ b/tests/unit/IpcSerialPort.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 // Mock child_process.execSync so registry queries don't affect test counts
 vi.mock('child_process', () => ({
@@ -307,6 +307,74 @@ describe('IpcSerialPort', () => {
     it('init should not throw', () => {
       const instance = IpcSerialPort.getInstance()
       expect(() => instance.init(null, {})).not.toThrow()
+    })
+  })
+
+  describe('hotplug watch', () => {
+    beforeEach(async () => {
+      vi.useFakeTimers()
+      IpcSerialPort.getInstance().stopHotplugWatch()
+      // 显式重置基线列表（mockResolvedValue 的实现会跨测试残留）
+      const { SerialPort } = await import('serialport')
+      vi.mocked(SerialPort.list).mockResolvedValue([
+        { path: '/dev/ttyUSB0', manufacturer: 'Test Mfr', friendlyName: 'Test Serial Port' }
+      ])
+    })
+
+    afterEach(() => {
+      IpcSerialPort.getInstance().stopHotplugWatch()
+      vi.useRealTimers()
+    })
+
+    it('should notify renderer when ports change', async () => {
+      const { SerialPort } = await import('serialport')
+      const instance = IpcSerialPort.getInstance()
+      const send = vi.fn()
+      instance.windows = { mainWindow: { webContents: { send } } }
+
+      instance.startHotplugWatch()
+      // 让基线 Promise 落定
+      await vi.advanceTimersByTimeAsync(0)
+      expect(send).not.toHaveBeenCalled()
+
+      // 模拟插入新串口
+      vi.mocked(SerialPort.list).mockResolvedValue([
+        { path: '/dev/ttyUSB0', manufacturer: 'Test Mfr', friendlyName: 'Test Serial Port' },
+        { path: '/dev/ttyUSB1', manufacturer: 'Test Mfr', friendlyName: 'Test Serial Port 2' }
+      ])
+
+      await vi.advanceTimersByTimeAsync(2000)
+      expect(send).toHaveBeenCalledTimes(1)
+      expect(send).toHaveBeenCalledWith(
+        'on-serial-ports-changed',
+        expect.arrayContaining([expect.objectContaining({ path: '/dev/ttyUSB1' })])
+      )
+    })
+
+    it('should not notify when ports are unchanged', async () => {
+      const instance = IpcSerialPort.getInstance()
+      const send = vi.fn()
+      instance.windows = { mainWindow: { webContents: { send } } }
+
+      instance.startHotplugWatch()
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(6000)
+      expect(send).not.toHaveBeenCalled()
+    })
+
+    it('should not throw when window is unavailable', async () => {
+      const { SerialPort } = await import('serialport')
+      const instance = IpcSerialPort.getInstance()
+      instance.windows = {}
+
+      instance.startHotplugWatch()
+      await vi.advanceTimersByTimeAsync(0)
+
+      vi.mocked(SerialPort.list).mockResolvedValue([
+        { path: '/dev/ttyUSB9', manufacturer: 'Test Mfr', friendlyName: 'Late Port' }
+      ])
+      // 窗口不存在时不抛错
+      await expect(vi.advanceTimersByTimeAsync(2000)).resolves.not.toThrow()
     })
   })
 })

--- a/tests/unit/IpcSerialPort.test.ts
+++ b/tests/unit/IpcSerialPort.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-// Mock child_process.execSync so registry queries don't affect test counts
+// Mock child_process.execFile so registry queries don't affect test counts
+// execFile 为回调式异步接口：cb(error, stdout)
 vi.mock('child_process', () => ({
-  execSync: vi.fn().mockReturnValue('')
+  execFile: vi.fn(
+    (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, stdout: string) => void) =>
+      cb(null, '')
+  )
 }))
 
 // Mock serialport
@@ -153,7 +157,7 @@ describe('IpcSerialPort', () => {
   })
 
   describe('getWindowsRegistryPorts (via listSerialPorts on win32)', () => {
-    it('should supplement ports from registry when execSync returns valid data', async () => {
+    it('should supplement ports from registry when execFile returns valid data', async () => {
       // Simulate Windows platform
       const platformStub = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
 
@@ -163,10 +167,11 @@ describe('IpcSerialPort', () => {
         { path: 'COM1', manufacturer: 'USB', serialNumber: 'SN1' }
       ])
 
-      const { execSync } = await import('child_process')
+      const { execFile } = await import('child_process')
       // registry returns COM55 and COM56
-      ;(execSync as any).mockReturnValueOnce(
-        '    \\Device\\com0com10    REG_SZ    COM55\r\n    \\Device\\com0com20    REG_SZ    COM56\r\n'
+      ;(execFile as any).mockImplementationOnce(
+        (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, stdout: string) => void) =>
+          cb(null, '    \\Device\\com0com10    REG_SZ    COM55\r\n    \\Device\\com0com20    REG_SZ    COM56\r\n')
       )
 
       const instance = IpcSerialPort.getInstance()
@@ -188,10 +193,11 @@ describe('IpcSerialPort', () => {
         { path: 'COM55', manufacturer: 'Virtual' }
       ])
 
-      const { execSync } = await import('child_process')
+      const { execFile } = await import('child_process')
       // registry returns COM55 (duplicate) and COM56 (new)
-      ;(execSync as any).mockReturnValueOnce(
-        '    \\Device\\com0com10    REG_SZ    COM55\r\n    \\Device\\com0com20    REG_SZ    COM56\r\n'
+      ;(execFile as any).mockImplementationOnce(
+        (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, stdout: string) => void) =>
+          cb(null, '    \\Device\\com0com10    REG_SZ    COM55\r\n    \\Device\\com0com20    REG_SZ    COM56\r\n')
       )
 
       const instance = IpcSerialPort.getInstance()
@@ -212,8 +218,11 @@ describe('IpcSerialPort', () => {
         { path: 'COM1' }
       ])
 
-      const { execSync } = await import('child_process')
-      ;(execSync as any).mockReturnValueOnce('')
+      const { execFile } = await import('child_process')
+      ;(execFile as any).mockImplementationOnce(
+        (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, stdout: string) => void) =>
+          cb(null, '')
+      )
 
       const instance = IpcSerialPort.getInstance()
       const ports = await instance.listSerialPorts()
@@ -224,7 +233,7 @@ describe('IpcSerialPort', () => {
       platformStub.mockRestore()
     })
 
-    it('should handle execSync throwing error gracefully', async () => {
+    it('should handle execFile error gracefully', async () => {
       const platformStub = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
 
       const { SerialPort } = await import('serialport')
@@ -232,10 +241,11 @@ describe('IpcSerialPort', () => {
         { path: 'COM1' }
       ])
 
-      const { execSync } = await import('child_process')
-      ;(execSync as any).mockImplementationOnce(() => {
-        throw new Error('registry access denied')
-      })
+      const { execFile } = await import('child_process')
+      ;(execFile as any).mockImplementationOnce(
+        (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, stdout: string) => void) =>
+          cb(new Error('registry access denied'), '')
+      )
 
       const instance = IpcSerialPort.getInstance()
       const ports = await instance.listSerialPorts()
@@ -253,12 +263,16 @@ describe('IpcSerialPort', () => {
       const { SerialPort } = await import('serialport')
       ;(SerialPort.list as any).mockResolvedValueOnce([])
 
-      const { execSync } = await import('child_process')
+      const { execFile } = await import('child_process')
       // Mix of different device names and COM port numbers
-      ;(execSync as any).mockReturnValueOnce(
-        '    \\Device\\VSerial_0    REG_SZ    COM20\r\n' +
-        '    \\Device\\BthModem0    REG_SZ    COM7\r\n' +
-        '    \\Device\\com0com11    REG_SZ    COM66\r\n'
+      ;(execFile as any).mockImplementationOnce(
+        (_cmd: string, _args: string[], _opts: object, cb: (err: Error | null, stdout: string) => void) =>
+          cb(
+            null,
+            '    \\Device\\VSerial_0    REG_SZ    COM20\r\n' +
+            '    \\Device\\BthModem0    REG_SZ    COM7\r\n' +
+            '    \\Device\\com0com11    REG_SZ    COM66\r\n'
+          )
       )
 
       const instance = IpcSerialPort.getInstance()
@@ -282,9 +296,9 @@ describe('IpcSerialPort', () => {
         { path: '/dev/ttyprintk' }
       ])
 
-      const { execSync } = await import('child_process')
-      // Even if execSync would return something, it should not be called on Linux
-      const execSyncSpy = vi.spyOn({ execSync }, 'execSync')
+      const { execFile } = await import('child_process')
+      const execFileSpy = vi.mocked(execFile)
+      execFileSpy.mockClear()
 
       const instance = IpcSerialPort.getInstance()
       const ports = await instance.listSerialPorts()
@@ -292,7 +306,7 @@ describe('IpcSerialPort', () => {
       // Only ttyUSB0 passes Linux filter
       expect(ports).toHaveLength(1)
       expect(ports[0].path).toBe('/dev/ttyUSB0')
-      expect(execSyncSpy).not.toHaveBeenCalled()
+      expect(execFileSpy).not.toHaveBeenCalled()
 
       platformStub.mockRestore()
     })


### PR DESCRIPTION
## 背景

1. **未插入串口启动应用时无法恢复**：侧边栏 COM 分组整体隐藏在 `v-if="serialPorts.length > 0"` 下，串口列表为空时连手动刷新按钮也看不到，之后插入串口界面无任何反应
2. 串口列表只在应用启动时加载一次，运行期间插拔不会自动更新

## 改动

**1. 主进程 `IpcSerialPort` 新增热插拔监听**

- 每 2s 轮询串口列表，用路径签名 diff，**仅在插拔变化时**通过 `on-serial-ports-changed` 事件推送渲染进程
- 采用轮询而非原生事件（WM_DEVICECHANGE / udev / IOKit）：无需新增原生依赖，Windows/Linux/macOS 行为一致
- 轮询走静默模式（`listSerialPorts(logResult = false)`），不产生日志；仅插拔瞬间记录一条 change 日志
- 定时器 `unref` 不阻止进程退出；提供 `stopHotplugWatch()`

**2. preload 新增 `onSerialPortsChanged` 订阅**（返回取消订阅函数，与现有 onRecvData 等事件同风格）

**3. 渲染进程订阅事件整体替换串口列表**（含串口类型解析；插拔频率低，全量替换即可）

**4. COM 分组常驻显示**：无串口时展示空态提示（暂无串口 / No serial ports），刷新按钮始终可用作为兜底

**5. 顺带把 `IpcSerialPort` 几处 `any` 收窄为具体类型**（新增 `WindowsRef` 接口）

## 副作用说明

- Windows 下每 2s 会执行一次 `reg query SERIALCOMM`（注册表补全虚拟串口），开销极小；该机制同时让 com0com 虚拟串口对的新增/删除也能被自动感知
- 多实例场景各实例独立轮询，互不影响

## 测试

- 新增 3 个热插拔单测（变化时通知 / 无变化不通知 / 窗口不存在时不抛错），fake timers 模拟插拔
- typecheck、eslint 通过（lint 错误数较改前减少 4 个）
- 本地实测（Linux）：插拔 USB 串口，侧边栏 2 秒内自动刷新；未插串口启动时 COM 分组可见、可手动刷新