### PR TITLE
为 Telnet 增加多字符编码支持

### DIFF
--- a/src/main/protocol/BufferLineSplitter.ts
+++ b/src/main/protocol/BufferLineSplitter.ts
@@ -47,6 +47,122 @@ export class BufferLineSplitter {
   }
 
   /**
+   * 解码可安全输出的完整字符，并返回需要留到下一批的残缺字节。
+   * 用于 Telnet 超长无换行数据的有界刷新。
+   */
+  decodeCompletePrefix(buffer: Buffer): { text: string; remainder: Buffer } {
+    if (this.receiveHex || buffer.length === 0) {
+      return { text: this.decodeFull(buffer), remainder: Buffer.alloc(0) }
+    }
+
+    const encoding = this.encoding.toLowerCase().replace(/_/g, '-')
+    let splitAt = buffer.length
+
+    if (['utf8', 'utf-8'].includes(encoding)) {
+      splitAt = this.getUtf8CompleteLength(buffer)
+    } else if (['utf16le', 'utf-16le', 'ucs2', 'ucs-2'].includes(encoding)) {
+      splitAt = this.getUtf16CompleteLength(buffer, true)
+    } else if (['utf16be', 'utf-16be'].includes(encoding)) {
+      splitAt = this.getUtf16CompleteLength(buffer, false)
+    } else if (encoding === 'gb18030') {
+      splitAt = this.getGb18030CompleteLength(buffer)
+    } else if (['gbk', 'cp936'].includes(encoding)) {
+      splitAt = this.getDbcsCompleteLength(buffer, (byte) => byte >= 0x81 && byte <= 0xfe)
+    } else if (['gb2312', 'euc-cn'].includes(encoding)) {
+      splitAt = this.getDbcsCompleteLength(buffer, (byte) => byte >= 0xa1 && byte <= 0xf7)
+    } else if (['big5', 'big-5', 'cp950'].includes(encoding)) {
+      splitAt = this.getDbcsCompleteLength(buffer, (byte) => byte >= 0x81 && byte <= 0xfe)
+    } else if (['shift-jis', 'shiftjis', 'sjis', 'cp932'].includes(encoding)) {
+      splitAt = this.getDbcsCompleteLength(
+        buffer,
+        (byte) => (byte >= 0x81 && byte <= 0x9f) || (byte >= 0xe0 && byte <= 0xfc)
+      )
+    } else if (['euc-kr', 'euckr', 'cp949'].includes(encoding)) {
+      splitAt = this.getDbcsCompleteLength(buffer, (byte) => byte >= 0x81 && byte <= 0xfe)
+    }
+
+    return {
+      text: this.decodeBuffer(buffer, 0, splitAt),
+      // Buffer.subarray() 会继续引用整个大 Buffer，复制后才能真正释放它。
+      remainder: Buffer.from(buffer.subarray(splitAt))
+    }
+  }
+
+  private getUtf8CompleteLength(buffer: Buffer): number {
+    let sequenceStart = buffer.length - 1
+    while (sequenceStart >= 0 && (buffer[sequenceStart] & 0xc0) === 0x80) {
+      sequenceStart--
+    }
+
+    if (sequenceStart < 0) {
+      // 全部是孤立的 continuation byte，属于非法 UTF-8；直接按替代字符输出，
+      // 不能把异常输入永久留在有界缓冲区中。
+      return buffer.length
+    }
+
+    const leadByte = buffer[sequenceStart]
+    const expectedLength = leadByte < 0x80 ? 1
+      : (leadByte & 0xe0) === 0xc0 ? 2
+        : (leadByte & 0xf0) === 0xe0 ? 3
+          : (leadByte & 0xf8) === 0xf0 ? 4
+            : 1
+    const completeLength = buffer.length - sequenceStart
+    return completeLength < expectedLength ? sequenceStart : buffer.length
+  }
+
+  private getUtf16CompleteLength(buffer: Buffer, littleEndian: boolean): number {
+    let length = buffer.length - (buffer.length % 2)
+    if (length < 2) return 0
+
+    const lastCodeUnit = littleEndian
+      ? buffer.readUInt16LE(length - 2)
+      : buffer.readUInt16BE(length - 2)
+    if (lastCodeUnit >= 0xd800 && lastCodeUnit <= 0xdbff) {
+      length -= 2
+    }
+    return length
+  }
+
+  private getDbcsCompleteLength(buffer: Buffer, isLeadByte: (byte: number) => boolean): number {
+    let offset = 0
+    while (offset < buffer.length) {
+      if (!isLeadByte(buffer[offset])) {
+        offset++
+      } else if (offset + 1 >= buffer.length) {
+        return offset
+      } else {
+        offset += 2
+      }
+    }
+    return offset
+  }
+
+  private getGb18030CompleteLength(buffer: Buffer): number {
+    let offset = 0
+    while (offset < buffer.length) {
+      const first = buffer[offset]
+      if (first <= 0x7f || first === 0x80 || first === 0xff) {
+        offset++
+        continue
+      }
+      if (first < 0x81 || first > 0xfe) {
+        offset++
+        continue
+      }
+      if (offset + 1 >= buffer.length) return offset
+
+      const second = buffer[offset + 1]
+      if (second >= 0x30 && second <= 0x39) {
+        if (offset + 3 >= buffer.length) return offset
+        offset += 4
+      } else {
+        offset += 2
+      }
+    }
+    return offset
+  }
+
+  /**
    * 将 Buffer 片段解码为字符串。
    * - HEX 模式：直接输出 hex 字符串（如 "aa 22 0d 0a 61 05"），不经过任何字符编码层
    * - STR 模式：按 encoding 解码（utf8/gb2312/gbk 等）
@@ -91,6 +207,14 @@ export class BufferLineSplitter {
         count: hexData ? 1 : 0,
         remainder: Buffer.alloc(0)
       }
+    }
+
+    const normalizedEncoding = this.encoding.toLowerCase().replace(/_/g, '-')
+    if (['utf16le', 'utf-16le', 'ucs2', 'ucs-2'].includes(normalizedEncoding)) {
+      return this.splitUtf16(buffer, true)
+    }
+    if (['utf16be', 'utf-16be'].includes(normalizedEncoding)) {
+      return this.splitUtf16(buffer, false)
     }
 
     const CR = 0x0d
@@ -149,6 +273,37 @@ export class BufferLineSplitter {
       log: resultLog,
       count: dataLines.length,
       remainder: resultRemainder
+    }
+  }
+
+  private splitUtf16(buffer: Buffer, littleEndian: boolean): LineSplitResult {
+    const dataLines: string[] = []
+    const logLines: string[] = []
+    const completeLength = buffer.length - (buffer.length % 2)
+    let offset = 0
+
+    for (let pos = 0; pos < completeLength; pos += 2) {
+      const codeUnit = littleEndian ? buffer.readUInt16LE(pos) : buffer.readUInt16BE(pos)
+      if (codeUnit !== 0x0d && codeUnit !== 0x0a) continue
+
+      const line = this.decodeBuffer(buffer, offset, pos)
+      if (line) {
+        dataLines.push(line)
+        logLines.push(this.toLogLine(line))
+      }
+
+      if (codeUnit === 0x0d && pos + 3 < completeLength) {
+        const next = littleEndian ? buffer.readUInt16LE(pos + 2) : buffer.readUInt16BE(pos + 2)
+        if (next === 0x0a) pos += 2
+      }
+      offset = pos + 2
+    }
+
+    return {
+      data: dataLines.join('\n'),
+      log: logLines.join('\n'),
+      count: dataLines.length,
+      remainder: Buffer.from(buffer.subarray(offset))
     }
   }
 

--- a/src/main/protocol/TelnetClient.ts
+++ b/src/main/protocol/TelnetClient.ts
@@ -2,6 +2,7 @@ import { Telnet } from 'telnet-client'
 import BaseClient, { ILogger } from './BaseClient'
 import ConnectionInfo from './ConnectionInfo'
 import { BufferLineSplitter } from './BufferLineSplitter'
+import * as iconv from 'iconv-lite'
 
 const DEFAULT_TELNET_PORT = 23
 const DEFAULT_TIMOUT_MS = 10 * 1000
@@ -11,6 +12,7 @@ const READ_INTERVAL_MS = 10 // 固定10ms读取间隔
 interface TelnetConnectionInfo {
   host: string
   port: number
+  encoding: string
 }
 
 interface TelnetConnection {
@@ -75,7 +77,8 @@ export default class TelnetClient extends BaseClient {
 
       await connection.connect(params)
       this.telnetConnections.set(sessionId, connection)
-      this.connectionInfos.set(sessionId, { host, port: port || DEFAULT_TELNET_PORT })
+      const encoding = info.encoding || 'utf8'
+      this.connectionInfos.set(sessionId, { host, port: port || DEFAULT_TELNET_PORT, encoding })
 
       // 存储连接数据对象
       const connData: TelnetConnection = {
@@ -85,7 +88,7 @@ export default class TelnetClient extends BaseClient {
         onData,
         onClose,
         onLog,
-        splitter: new BufferLineSplitter('utf8', false)
+        splitter: new BufferLineSplitter(encoding, false)
       }
       this.telnetConnectionData.set(sessionId, connData)
 
@@ -109,7 +112,7 @@ export default class TelnetClient extends BaseClient {
         // 关闭前输出缓冲区中剩余的数据
         if (connData.buffer && connData.buffer.length > 0) {
           const timestamp = BufferLineSplitter.timestamp()
-          const remainingStr = connData.buffer.toString('utf8')
+          const remainingStr = connData.splitter.decodeFull(connData.buffer)
           connData.onData?.({ data: remainingStr, timestamp })
           connData.onLog?.(remainingStr, timestamp)
           connData.buffer = Buffer.alloc(0)
@@ -139,7 +142,8 @@ export default class TelnetClient extends BaseClient {
 
     try {
       const dataStr = `[${BufferLineSplitter.timestamp()}] SEND >>>>>>>>>> ${command}`
-      await connection.send(command + '\n')
+      const encoding = this.connectionInfos.get(connId)?.encoding || 'utf8'
+      await connection.send(iconv.encode(command + '\n', encoding))
       onComplete?.(dataStr)
 
       this.logger.info(`send command: ${command}`)

--- a/src/renderer/src/components/ConnectionDialog.vue
+++ b/src/renderer/src/components/ConnectionDialog.vue
@@ -76,6 +76,26 @@
         <el-form-item :label="t('dialog.password')" prop="password" v-if="['ftp', 'tftp', 'http'].includes(formData.connectionType)">
           <el-input v-model="(formData as any).password" :placeholder="t('dialog.passwordPlaceholder')" type="password" />
         </el-form-item>
+        <el-form-item :label="t('comTerminal.encoding')" v-if="formData.connectionType === 'telnet'">
+          <el-select v-model="formData.encoding" style="width: 100%">
+            <el-option label="UTF-8" value="utf8" />
+            <el-option label="GB2312" value="gb2312" />
+            <el-option label="GBK" value="gbk" />
+            <el-option label="GB18030" value="gb18030" />
+            <el-option label="BIG5" value="big5" />
+            <el-option label="Shift-JIS" value="shift-jis" />
+            <el-option label="EUC-KR" value="euc-kr" />
+            <el-option label="ASCII" value="ascii" />
+            <el-option label="ISO-8859-1" value="latin1" />
+            <el-option label="ISO-8859-2" value="latin2" />
+            <el-option label="KOI8-R" value="koi8-r" />
+            <el-option label="windows-1251" value="windows-1251" />
+            <el-option label="windows-1252" value="windows-1252" />
+            <el-option label="ISO-8859-5" value="iso-8859-5" />
+            <el-option label="UTF-16LE" value="utf16le" />
+            <el-option label="UTF-16BE" value="utf16be" />
+          </el-select>
+        </el-form-item>
       </template>
     </el-form>
     <template #footer>

--- a/src/renderer/src/components/TelnetTerminal.vue
+++ b/src/renderer/src/components/TelnetTerminal.vue
@@ -46,6 +46,7 @@ const props = withDefaults(defineProps<{
     name?: string
     sessionId: string | number
     ftpMode?: string
+    encoding?: string
   }
   onClose?: () => void
   autoConnect?: boolean

--- a/src/renderer/src/entity/protocol/base.ts
+++ b/src/renderer/src/entity/protocol/base.ts
@@ -21,6 +21,7 @@ export interface TelnetConnection extends BaseConnection {
   port: number
   username: string
   password: string
+  encoding: string
 }
 
 export interface SshConnection extends BaseConnection {

--- a/src/renderer/src/entity/protocol/telnet.ts
+++ b/src/renderer/src/entity/protocol/telnet.ts
@@ -8,7 +8,8 @@ export const TelnetStrategy = {
       host: '',
       port: 23,
       username: '',
-      password: ''
+      password: '',
+      encoding: 'utf8'
     }
   },
 
@@ -20,7 +21,8 @@ export const TelnetStrategy = {
       host: raw.host || '',
       port: raw.port || 23,
       username: raw.username || '',
-      password: raw.password || ''
+      password: raw.password || '',
+      encoding: raw.encoding || 'utf8'
     }
   }
 }

--- a/tests/unit/BufferLineSplitter.test.ts
+++ b/tests/unit/BufferLineSplitter.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import * as iconv from 'iconv-lite'
 import { BufferLineSplitter } from '../../src/main/protocol/BufferLineSplitter'
 
 describe('BufferLineSplitter', () => {
@@ -171,6 +172,142 @@ describe('BufferLineSplitter', () => {
       expect(splitter.toLogLine('41 42')).toBe('41 42')
       splitter.updateReceiveHex(false)
       expect(splitter.toLogLine('AB')).toBe('AB')
+    })
+  })
+
+  describe('decodeCompletePrefix', () => {
+    it('完整 UTF-8 内容全部输出', () => {
+      const splitter = new BufferLineSplitter('utf8')
+      const result = splitter.decodeCompletePrefix(Buffer.from('abc你好'))
+
+      expect(result.text).toBe('abc你好')
+      expect(result.remainder.length).toBe(0)
+    })
+
+    it('保留跨批次的 UTF-8 残缺字符', () => {
+      const splitter = new BufferLineSplitter('utf8')
+      const encoded = Buffer.from('abc中')
+      const first = splitter.decodeCompletePrefix(encoded.subarray(0, encoded.length - 1))
+
+      expect(first.text).toBe('abc')
+      expect(first.remainder).toEqual(encoded.subarray(3, encoded.length - 1))
+
+      const second = splitter.decodeCompletePrefix(
+        Buffer.concat([first.remainder, encoded.subarray(encoded.length - 1)])
+      )
+      expect(second.text).toBe('中')
+      expect(second.remainder.length).toBe(0)
+    })
+
+    it('保留四字节 UTF-8 字符的残缺尾部', () => {
+      const splitter = new BufferLineSplitter('utf-8')
+      const encoded = Buffer.from('x😀')
+      const result = splitter.decodeCompletePrefix(encoded.subarray(0, encoded.length - 1))
+
+      expect(result.text).toBe('x')
+      expect(result.remainder.length).toBe(3)
+    })
+
+    it('非法 continuation byte 不会永久滞留', () => {
+      const splitter = new BufferLineSplitter('utf8')
+      const result = splitter.decodeCompletePrefix(Buffer.from([0x80, 0x80, 0x80]))
+
+      expect(result.text).not.toBe('')
+      expect(result.remainder.length).toBe(0)
+    })
+
+    it.each([
+      ['1 字节 ASCII', 'A'],
+      ['2 字节字符', 'é'],
+      ['3 字节字符', '中'],
+      ['4 字节 Emoji', '😀'],
+      ['Unicode 最大码点', String.fromCodePoint(0x10ffff)]
+    ])('%s 在每个字节边界都可无损重组', (_name, character) => {
+      const splitter = new BufferLineSplitter('utf8')
+      const encoded = Buffer.from(`prefix${character}`)
+      const characterStart = Buffer.byteLength('prefix')
+
+      for (let splitAt = characterStart; splitAt <= encoded.length; splitAt++) {
+        const first = splitter.decodeCompletePrefix(encoded.subarray(0, splitAt))
+        const second = splitter.decodeCompletePrefix(
+          Buffer.concat([first.remainder, encoded.subarray(splitAt)])
+        )
+
+        expect(first.text + second.text).toBe(`prefix${character}`)
+        expect(second.remainder.length).toBe(0)
+      }
+    })
+
+    it.each([
+      ['组合字符', 'e\u0301'],
+      ['生僻字', '𠮷'],
+      ['ZWJ Emoji', '👨‍👩‍👧‍👦'],
+      ['旗帜 Emoji', '🇨🇳'],
+      ['多语言文本', '中文 العربية हिन्दी 日本語 한글']
+    ])('%s 跨任意字节边界后内容不变', (_name, text) => {
+      const splitter = new BufferLineSplitter('utf8')
+      const encoded = Buffer.from(text)
+
+      for (let splitAt = 0; splitAt <= encoded.length; splitAt++) {
+        const first = splitter.decodeCompletePrefix(encoded.subarray(0, splitAt))
+        const second = splitter.decodeCompletePrefix(
+          Buffer.concat([first.remainder, encoded.subarray(splitAt)])
+        )
+
+        expect(first.text + second.text).toBe(text)
+        expect(second.remainder.length).toBe(0)
+      }
+    })
+
+    it.each([
+      ['gb2312', '中文测试'],
+      ['gbk', '中文€测试'],
+      ['gb18030', '中文😀测试'],
+      ['big5', '繁體中文'],
+      ['shift-jis', '日本語テスト'],
+      ['euc-kr', '한국어 테스트'],
+      ['utf16le', '中文😀test'],
+      ['utf16be', '中文😀test']
+    ])('%s 在每个字节边界都可无损重组', (encoding, text) => {
+      const splitter = new BufferLineSplitter(encoding)
+      const encoded = iconv.encode(text, encoding)
+
+      for (let splitAt = 0; splitAt <= encoded.length; splitAt++) {
+        const first = splitter.decodeCompletePrefix(encoded.subarray(0, splitAt))
+        const second = splitter.decodeCompletePrefix(
+          Buffer.concat([first.remainder, encoded.subarray(splitAt)])
+        )
+
+        expect(first.text + second.text).toBe(text)
+        expect(second.remainder.length).toBe(0)
+      }
+    })
+
+    it.each([
+      ['ascii', 'ASCII test'],
+      ['latin1', 'café'],
+      ['latin2', 'Zażółć'],
+      ['koi8-r', 'Русский'],
+      ['windows-1251', 'Русский'],
+      ['windows-1252', 'café €'],
+      ['iso-8859-5', 'Русский']
+    ])('%s 单字节编码可完整输出', (encoding, text) => {
+      const splitter = new BufferLineSplitter(encoding)
+      const result = splitter.decodeCompletePrefix(iconv.encode(text, encoding))
+
+      expect(result.text).toBe(text)
+      expect(result.remainder.length).toBe(0)
+    })
+  })
+
+  describe('split - UTF-16 换行', () => {
+    it.each(['utf16le', 'utf16be'])('%s 正确解析 CRLF 和 LF', (encoding) => {
+      const splitter = new BufferLineSplitter(encoding)
+      const result = splitter.split(iconv.encode('第一行\r\n第二行\n', encoding))
+
+      expect(result.data).toBe('第一行\n第二行')
+      expect(result.count).toBe(2)
+      expect(result.remainder.length).toBe(0)
     })
   })
 

--- a/tests/unit/ProtocolStrategies.test.ts
+++ b/tests/unit/ProtocolStrategies.test.ts
@@ -104,7 +104,8 @@ describe('Protocol Strategies', () => {
     host: '',
     port: 23,
     username: '',
-    password: ''
+    password: '',
+    encoding: 'utf8'
   }, 'telnet')
 
   // SSH Strategy

--- a/tests/unit/TelnetClient.test.ts
+++ b/tests/unit/TelnetClient.test.ts
@@ -3,6 +3,7 @@
  * 使用 mock 的 telnet-client 库测试 TelnetClient 核心逻辑
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import * as iconv from 'iconv-lite'
 
 // Mock telnet-client
 vi.mock('telnet-client', () => {
@@ -228,6 +229,19 @@ describe('TelnetClient', () => {
       expect(r1.success).toBe(true)
       expect(r2.success).toBe(true)
       expect(r3.success).toBe(true)
+    })
+
+    it('should encode commands with the connection encoding', async () => {
+      await client.start(
+        { host: '1.2.3.4', port: 23, username: '', password: '', sessionId: 'gbk', encoding: 'gbk' },
+        vi.fn(), vi.fn(), vi.fn()
+      )
+      const connection = client.telnetConnections.get('gbk')!
+      const sendSpy = vi.spyOn(connection, 'send')
+
+      await client.send('gbk', '中文命令', vi.fn())
+
+      expect(sendSpy).toHaveBeenCalledWith(iconv.encode('中文命令\n', 'gbk'))
     })
   })
 


### PR DESCRIPTION
## 背景

Telnet 连接当前默认按 UTF-8 处理，但部分中文、日文、韩文及传统设备使用其他字符编码，导致接收数据显示乱码、发送非 ASCII 命令失败。

## 本次变更

- 为 Telnet 连接增加编码选择并持久化配置。
- 接收数据按每个连接的编码解码。
- 发送命令按每个连接的编码编码。
- 支持 UTF-8、GB2312、GBK、GB18030、BIG5、Shift-JIS、EUC-KR、ASCII、ISO-8859 系列、KOI8-R、Windows-1251/1252、UTF-16LE/BE。
- 支持多字节字符跨网络数据包边界安全重组。
- 支持 GB18030 四字节字符边界。
- 支持 UTF-16LE/BE 双字节 CR/LF 换行解析。
- 历史连接未保存编码字段时默认回退 UTF-8。

## 兼容性

- 默认行为保持 UTF-8，不影响现有 Telnet 连接。
- 只有用户选择其他编码后，连接才使用对应编码收发数据。
- 本 PR 不包含终端内存优化、日志限制或 IPC 改动。

## 验证

- `npm run typecheck`
- 相关单元测试通过
- 129 个编码、Telnet 和协议策略测试通过
- 覆盖 UTF-8 1 至 4 字节字符、中文、生僻字、组合字符、ZWJ Emoji、多语言文本及多种传统编码

## 自动化署名

本次代码由 OpenCode（GPT-5.6 Sol）自动完成，包括代码修改、测试验证和 PR 内容整理。

请维护者确认是否有意向接收该编码功能；如希望减少编码列表或调整编码字段位置，我可以配合修改。
