### PR TITLE
修复无换行数据流下接收缓冲区无限增长

### DIFF
--- a/src/main/protocol/ComClient.ts
+++ b/src/main/protocol/ComClient.ts
@@ -11,6 +11,7 @@ const DEFAULT_PARITY = 'none' as const
 const DEFAULT_ENCODING = 'utf8'
 const READ_INTERVAL_MS = 10 // 固定10ms读取间隔
 const FLUSH_TIMEOUT_MS = 100 // 空闲超时：buffer 中有数据但超过此时间无新数据到达，强制刷新
+const MAX_BUFFER_BYTES = 1024 * 1024 // 无换行输出也必须有上限，避免接收缓冲区无限增长
 
 interface SerialConnection {
   port: SerialPort
@@ -47,6 +48,19 @@ export default class ComClient extends BaseClient {
         const timestamp = BufferLineSplitter.timestamp()
         onData?.({ data: result.data, timestamp })
         onLog?.(result.log, timestamp)
+      }
+
+      // 空闲刷新只对"停止发送"生效；若设备持续发送不带换行符的内容（如用 \b
+      // 刷进度条），split() 会一直保留 remainder，必须有界刷新，否则 Buffer 随运行时间无限增长。
+      if (connection.buffer.length > MAX_BUFFER_BYTES) {
+        const timestamp = BufferLineSplitter.timestamp()
+        const flushed = splitter.decodeCompletePrefix(connection.buffer)
+        connection.buffer = flushed.remainder
+        this.logger.info(`serial buffer cap flush: ${flushed.text.length} chars`)
+        if (flushed.text) {
+          onData?.({ data: flushed.text, timestamp })
+          onLog?.(splitter.toLogLine(flushed.text), timestamp)
+        }
       }
     } catch (err: any) {
       this.logger.error(`processBuffer error: ${err?.message || err}`)

--- a/src/main/protocol/TelnetClient.ts
+++ b/src/main/protocol/TelnetClient.ts
@@ -8,6 +8,7 @@ const DEFAULT_TELNET_PORT = 23
 const DEFAULT_TIMOUT_MS = 10 * 1000
 const DEFAULT_TERMINAL_TYPE = 'vt100' /* cmd 中默认常用 vt100 */
 const READ_INTERVAL_MS = 10 // 固定10ms读取间隔
+const MAX_BUFFER_BYTES = 1024 * 1024 // 无换行输出也必须有上限，避免接收缓冲区无限增长
 
 interface TelnetConnectionInfo {
   host: string
@@ -50,6 +51,19 @@ export default class TelnetClient extends BaseClient {
         const timestamp = BufferLineSplitter.timestamp()
         onData?.({ data: result.data, timestamp })
         onLog?.(result.log, timestamp)
+      }
+
+      // 某些设备会持续发送不带换行符的内容（如用 \b 刷进度条）。此时 split()
+      // 会一直保留 remainder，且数据永远到不了渲染进程（没有完整行），
+      // 终端的显示上限清空机制无法覆盖，必须有界刷新，否则 Buffer 随运行时间无限增长。
+      if (connData.buffer.length > MAX_BUFFER_BYTES) {
+        const timestamp = BufferLineSplitter.timestamp()
+        const flushed = splitter.decodeCompletePrefix(connData.buffer)
+        connData.buffer = flushed.remainder
+        if (flushed.text) {
+          onData?.({ data: flushed.text, timestamp })
+          onLog?.(flushed.text, timestamp)
+        }
       }
     } catch (err: any) {
       this.logger.error(`processBuffer error: ${err?.message || err}`)

--- a/tests/unit/ComClient.test.ts
+++ b/tests/unit/ComClient.test.ts
@@ -1,0 +1,126 @@
+/**
+ * ComClient 测试
+ * 使用 mock 的 serialport 库测试 ComClient 核心逻辑
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock serialport（原生模块，测试中无法加载）
+vi.mock('serialport', () => {
+  class MockSerialPort {
+    private listeners: Map<string, Function[]> = new Map()
+    path: string
+    baudRate: number
+
+    constructor(opts: any) {
+      this.path = opts.path
+      this.baudRate = opts.baudRate
+    }
+
+    on(event: string, callback: Function): void {
+      if (!this.listeners.has(event)) {
+        this.listeners.set(event, [])
+      }
+      this.listeners.get(event)!.push(callback)
+    }
+
+    once(event: string, callback: Function): void {
+      this.on(event, callback)
+    }
+
+    removeAllListeners(event?: string): void {
+      if (event) {
+        this.listeners.delete(event)
+      } else {
+        this.listeners.clear()
+      }
+    }
+
+    open(callback: (err: Error | null) => void): void {
+      setImmediate(() => {
+        this.emit('open')
+        callback(null)
+      })
+    }
+
+    write(_data: any, _encoding: any, callback: (err: Error | null) => void): void {
+      callback(null)
+    }
+
+    close(callback?: (err: Error | null) => void): void {
+      callback?.(null)
+    }
+
+    // Helper for tests
+    emit(event: string, ...args: any[]): void {
+      const cbs = this.listeners.get(event) || []
+      cbs.forEach(cb => cb(...args))
+    }
+  }
+
+  return { SerialPort: MockSerialPort }
+})
+
+import ComClient from '../../src/main/protocol/ComClient'
+
+describe('ComClient', () => {
+  let client: ComClient
+
+  beforeEach(() => {
+    client = new ComClient()
+  })
+
+  const startConnection = async (sessionId: string, onData = vi.fn(), onLog = vi.fn()) => {
+    const result = await client.start(
+      { comName: 'COM1', sessionId, host: '', port: 0, username: '', password: '' },
+      onData, vi.fn(), onLog
+    )
+    return { result, onData, onLog }
+  }
+
+  describe('start()', () => {
+    it('should return success on open', async () => {
+      const { result } = await startConnection('s1')
+      expect((result as any).success).toBe(true)
+      expect(client.serialConnections.has('s1')).toBe(true)
+    })
+
+    it('should fail without comName', async () => {
+      const result = await client.start(
+        { comName: '', sessionId: 's2', host: '', port: 0, username: '', password: '' },
+        vi.fn(), vi.fn(), vi.fn()
+      )
+      expect((result as any).success).toBe(false)
+    })
+  })
+
+  describe('receive buffer cap', () => {
+    it('should force-flush buffer exceeding 1MB when no newline arrives', async () => {
+      const onData = vi.fn()
+      const onLog = vi.fn()
+      await startConnection('cap-1', onData, onLog)
+
+      const connection = client.serialConnections.get('cap-1')!
+      // 模拟设备持续发送不带换行符的内容（split 会一直保留 remainder，
+      // 且持续有数据时空闲刷新 checkFlushBuffer 不会触发）
+      connection.buffer = Buffer.alloc(1024 * 1024 + 1, 'a')
+      ;(client as any).processBuffer(connection)
+
+      expect(onData).toHaveBeenCalledTimes(1)
+      expect(onData.mock.calls[0][0].data.length).toBe(1024 * 1024 + 1)
+      expect(onLog).toHaveBeenCalledTimes(1)
+      expect(connection.buffer.length).toBe(0)
+    })
+
+    it('should keep buffer below the cap for the next chunk', async () => {
+      const onData = vi.fn()
+      await startConnection('cap-2', onData)
+
+      const connection = client.serialConnections.get('cap-2')!
+      connection.buffer = Buffer.from('no newline yet')
+      ;(client as any).processBuffer(connection)
+
+      expect(onData).not.toHaveBeenCalled()
+      expect(connection.buffer.toString()).toBe('no newline yet')
+    })
+  })
+})

--- a/tests/unit/TelnetClient.test.ts
+++ b/tests/unit/TelnetClient.test.ts
@@ -79,6 +79,14 @@ vi.mock('../../src/main/protocol/BufferLineSplitter', () => ({
       return result.trim()
     }
 
+    decodeFull(buffer: Buffer): string {
+      return buffer.toString(this.encoding as BufferEncoding)
+    }
+
+    decodeCompletePrefix(buffer: Buffer): { text: string; remainder: Buffer } {
+      return { text: buffer.toString(this.encoding as BufferEncoding), remainder: Buffer.alloc(0) }
+    }
+
     static timestamp(): string {
       const now = new Date()
       return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')} ${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}:${String(now.getSeconds()).padStart(2, '0')}.${String(now.getMilliseconds()).padStart(3, '0')}`
@@ -242,6 +250,40 @@ describe('TelnetClient', () => {
       await client.send('gbk', '中文命令', vi.fn())
 
       expect(sendSpy).toHaveBeenCalledWith(iconv.encode('中文命令\n', 'gbk'))
+    })
+  })
+
+  describe('receive buffer cap', () => {
+    const makeCapInfo = (sessionId: string) => ({
+      host: '1.2.3.4', port: 23, username: '', password: '', sessionId
+    })
+
+    it('should force-flush buffer exceeding 1MB when no newline arrives', async () => {
+      const onData = vi.fn()
+      const onLog = vi.fn()
+      await client.start(makeCapInfo('cap-1'), onData, vi.fn(), onLog)
+
+      const connData = client.telnetConnectionData.get('cap-1')!
+      // 模拟设备持续发送不带换行符的内容（split 会一直保留 remainder）
+      connData.buffer = Buffer.alloc(1024 * 1024 + 1, 'a')
+      ;(client as any).processBuffer('cap-1')
+
+      expect(onData).toHaveBeenCalledTimes(1)
+      expect(onData.mock.calls[0][0].data.length).toBe(1024 * 1024 + 1)
+      expect(onLog).toHaveBeenCalledTimes(1)
+      expect(connData.buffer.length).toBe(0)
+    })
+
+    it('should keep buffer below the cap for the next chunk', async () => {
+      const onData = vi.fn()
+      await client.start(makeCapInfo('cap-2'), onData, vi.fn(), vi.fn())
+
+      const connData = client.telnetConnectionData.get('cap-2')!
+      connData.buffer = Buffer.from('no newline yet')
+      ;(client as any).processBuffer('cap-2')
+
+      expect(onData).not.toHaveBeenCalled()
+      expect(connData.buffer.toString()).toBe('no newline yet')
     })
   })
 


### PR DESCRIPTION
## 背景

拆分自已关闭的 #271。根据 #271 中的讨论重新做了代码走查和验证：

**渲染进程侧不存在无限增长**。现有 30MB 自动清空（`clearTerminal` → `setValue`）已连带覆盖显示文本、语法/ANSI 装饰器、logLines 缓存，Monaco 的 `setValue` 内部也会销毁整个 undo 编辑历史。压测几个 GB 日志内存稳定在 ~700MB 与此一致。因此 #271 中渲染端的改动（8MB 上限、50000 行裁剪、装饰器数量上限、关闭 undo）属于降低峰值，已撤回，不在本 PR 中。

**主进程接收缓冲区存在一处真实的无界累积**：当设备持续发送完全不含 `\r` `\n` 的数据时（如用 `\b` 退格刷进度条的设备），`BufferLineSplitter.split()` 永远返回全量 remainder，`Buffer.concat` 无限增长。关键点是这些数据因没有完整行**永远到不了渲染进程**，终端无任何输出，30MB 清空机制无法覆盖——表现为主进程/worker 内存持续上涨但界面无内容。日常带换行的日志流不会触发，因此常规压测复现不了。

串口 `ComClient` 虽有空闲刷新（`checkFlushBuffer`），但它只在连续超时无新数据时触发，**持续不断**的无换行串口流有同样的洞。

## 本次变更

- `TelnetClient`：接收缓冲区超过 1 MB 时，用 `decodeCompletePrefix` 按字符边界强制刷新（该函数已随 #272 合入，此前无调用方）。
- `ComClient`：串口侧同等保护，刷新行为与现有空闲刷新一致（按编码解码、保留不完整多字节字符边界）。
- 新增单元测试：Telnet/串口超过上限触发有界刷新、未超上限数据保留到下一块。

改动共 4 个文件，主流程代码 28 行。

## 兼容性

- 正常带换行的连接处理行为完全不变。
- HEX 接收模式下 `split()` 本就消费整个 buffer，上限路径不会触发。

## 验证

- `npm run typecheck` 通过
- `npm test` 通过：65 个测试文件、1173 个单元测试

## 关联

- 拆分自 #271（渲染端改动经复核后撤回）
- 依赖 #272 已合入的 `decodeCompletePrefix`

## 自动化署名

本次代码修改与测试验证由 OpenCode（kimi-k3）完成，人工核对后提交。