### PR TITLE
feat(serial): 支持显示串口友好名称与设备详细信息

### DIFF
--- a/src/main/storage/SettingsStorage.ts
+++ b/src/main/storage/SettingsStorage.ts
@@ -46,6 +46,8 @@ interface Settings extends Record<string, any> {
   // 串口设置
   supportedBaudRates?: number[]
   showPortType?: boolean
+  showSerialPortFriendlyName?: boolean
+  showSerialPortDetails?: boolean
   // 日志
   enableLogStorage?: boolean
   logPath?: string
@@ -88,6 +90,8 @@ const defaultSettings: Settings = {
   // 串口设置
   supportedBaudRates: [9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600, 1500000],
   showPortType: true,
+  showSerialPortFriendlyName: true,
+  showSerialPortDetails: false,
   // 日志
   enableLogStorage: true,
   logPath: '',

--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -35,6 +35,8 @@
         :filtered-serial-ports="filteredSerialPorts"
         :serial-port-expanded="serialPortExpanded"
         :show-port-type="showPortType"
+        :show-serial-port-friendly-name="showSerialPortFriendlyName"
+        :show-serial-port-details="showSerialPortDetails"
         :connection-groups="connectionGroups"
         :connection-group-expanded="connectionGroupExpanded"
         :serial-remarks="serialRemarks"
@@ -320,6 +322,7 @@ const panelRefs = reactive<Record<string, InstanceType<typeof TerminalPanel> | n
 const {
   connections, serialPorts,
   showConnectionList, sidebarWidth, serialPortExpanded, showPortType,
+  showSerialPortFriendlyName, showSerialPortDetails,
   connectionGroupExpanded, filteredSerialPorts, connectionGroups,
   handleSearch, loadConnections, loadSerialPorts, loadSidebarState,
   handleSerialPortsChanged, toggleConnectionList
@@ -1102,6 +1105,12 @@ const handleSettingsUpdated = (event: Event) => {
   const settings = (event as CustomEvent).detail
   if (settings && 'showPortType' in settings) {
     showPortType.value = settings.showPortType
+  }
+  if (settings && 'showSerialPortFriendlyName' in settings) {
+    showSerialPortFriendlyName.value = settings.showSerialPortFriendlyName
+  }
+  if (settings && 'showSerialPortDetails' in settings) {
+    showSerialPortDetails.value = settings.showSerialPortDetails
   }
 }
 

--- a/src/renderer/src/components/SettingsPage.vue
+++ b/src/renderer/src/components/SettingsPage.vue
@@ -154,6 +154,20 @@
               </div>
               <el-switch class="terminal-switch" v-model="settings.showPortType" />
             </div>
+            <div class="setting-item">
+              <div class="setting-label">
+                <span class="label-text">{{ t('serialSettings.showFriendlyName') }}</span>
+                <span class="label-desc">{{ t('serialSettings.showFriendlyNameDesc') }}</span>
+              </div>
+              <el-switch class="terminal-switch" v-model="settings.showSerialPortFriendlyName" />
+            </div>
+            <div class="setting-item">
+              <div class="setting-label">
+                <span class="label-text">{{ t('serialSettings.showPortDetails') }}</span>
+                <span class="label-desc">{{ t('serialSettings.showPortDetailsDesc') }}</span>
+              </div>
+              <el-switch class="terminal-switch" v-model="settings.showSerialPortDetails" />
+            </div>
           </div>
         </div>
 

--- a/src/renderer/src/components/app/ConnectionSidebar.vue
+++ b/src/renderer/src/components/app/ConnectionSidebar.vue
@@ -59,7 +59,7 @@
                             <div v-if="port.locationId" class="port-detail-row"><span class="port-detail-label">{{ t('sidebar.locationId') }}:</span> {{ port.locationId }}</div>
                           </div>
                         </template>
-                        <div class="serial-port-device">
+                        <div class="serial-port-device" tabindex="0">
                           <div class="serial-port-row">
                             <span class="conn-name">{{ port.path }}</span>
                             <span v-if="showPortType" class="serial-port-type">

--- a/src/renderer/src/components/app/ConnectionSidebar.vue
+++ b/src/renderer/src/components/app/ConnectionSidebar.vue
@@ -42,15 +42,40 @@
                       :class="isSerialPortConnected(port.path) ? 'connected' : 'disconnected'"
                     ></span>
                     <div class="serial-port-info">
-                      <div class="serial-port-row">
-                        <span class="conn-name">{{ port.path }}</span>
-                        <span v-if="showPortType" class="serial-port-type">
-                          <el-tag v-if="port.type === 'virtual'" type="info" size="small" effect="dark">{{ t('sidebar.virtual') }}</el-tag>
-                          <el-tag v-else-if="port.type === 'usb'" type="success" size="small" effect="dark">{{ t('sidebar.usb') }}</el-tag>
-                          <el-tag v-else-if="port.type === 'bluetooth'" class="bluetooth-tag" size="small" effect="dark">{{ t('sidebar.bluetooth') }}</el-tag>
-                          <el-tag v-else type="info" size="small" effect="dark">{{ t('sidebar.noType') }}</el-tag>
-                        </span>
-                      </div>
+                      <el-tooltip
+                        :disabled="!showSerialPortDetails || !hasPortDetails(port)"
+                        :show-after="TOOLTIP_SHOW_AFTER"
+                        placement="right"
+                        effect="dark"
+                        :enterable="false"
+                      >
+                        <template #content>
+                          <div class="port-detail-tooltip">
+                            <div v-if="port.friendlyName" class="port-detail-row"><span class="port-detail-label">{{ t('sidebar.friendlyName') }}:</span> {{ port.friendlyName }}</div>
+                            <div v-if="port.manufacturer" class="port-detail-row"><span class="port-detail-label">{{ t('sidebar.manufacturer') }}:</span> {{ port.manufacturer }}</div>
+                            <div v-if="port.vendorId || port.productId" class="port-detail-row"><span class="port-detail-label">VID/PID:</span> {{ port.vendorId || '-' }}/{{ port.productId || '-' }}</div>
+                            <div v-if="port.serialNumber" class="port-detail-row"><span class="port-detail-label">{{ t('sidebar.serialNumber') }}:</span> {{ port.serialNumber }}</div>
+                            <div v-if="port.pnpId" class="port-detail-row"><span class="port-detail-label">PnP ID:</span> {{ port.pnpId }}</div>
+                            <div v-if="port.locationId" class="port-detail-row"><span class="port-detail-label">{{ t('sidebar.locationId') }}:</span> {{ port.locationId }}</div>
+                          </div>
+                        </template>
+                        <div class="serial-port-device">
+                          <div class="serial-port-row">
+                            <span class="conn-name">{{ port.path }}</span>
+                            <span v-if="showPortType" class="serial-port-type">
+                              <el-tag v-if="port.type === 'virtual'" type="info" size="small" effect="dark">{{ t('sidebar.virtual') }}</el-tag>
+                              <el-tag v-else-if="port.type === 'usb'" type="success" size="small" effect="dark">{{ t('sidebar.usb') }}</el-tag>
+                              <el-tag v-else-if="port.type === 'bluetooth'" class="bluetooth-tag" size="small" effect="dark">{{ t('sidebar.bluetooth') }}</el-tag>
+                              <el-tag v-else type="info" size="small" effect="dark">{{ t('sidebar.noType') }}</el-tag>
+                            </span>
+                          </div>
+                          <span
+                            v-if="showSerialPortFriendlyName && getPortFriendlyName(port)"
+                            class="serial-friendly-name"
+                            :title="getPortFriendlyName(port)"
+                          >{{ getPortFriendlyName(port) }}</span>
+                        </div>
+                      </el-tooltip>
                       <el-tooltip v-if="serialRemarks[port.path]" :content="serialRemarks[port.path]" placement="top" effect="dark" :enterable="false" :show-after="TOOLTIP_SHOW_AFTER">
                         <span class="serial-remark">{{ serialRemarks[port.path] }}</span>
                       </el-tooltip>
@@ -178,6 +203,8 @@ const props = defineProps<{
   filteredSerialPorts: SerialPortInfo[]
   serialPortExpanded: boolean
   showPortType: boolean
+  showSerialPortFriendlyName: boolean
+  showSerialPortDetails: boolean
   connectionGroups: Record<string, any[]>
   connectionGroupExpanded: Record<string, boolean>
   serialRemarks: Record<string, string>
@@ -205,6 +232,25 @@ const handleClickOutside = (e: MouseEvent) => {
   if (sidebarMenuRef.value && !sidebarMenuRef.value.contains(e.target as Node)) {
     showSidebarMenu.value = false
   }
+}
+
+const getPortFriendlyName = (port: SerialPortInfo): string => {
+  const friendlyName = port.friendlyName?.trim()
+  if (!friendlyName) return ''
+  const escapedPath = port.path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return friendlyName.replace(new RegExp(`\\s*\\(${escapedPath}\\)\\s*$`, 'i'), '').trim()
+}
+
+const hasPortDetails = (port: SerialPortInfo): boolean => {
+  return !!(
+    port.friendlyName ||
+    port.manufacturer ||
+    port.vendorId ||
+    port.productId ||
+    port.serialNumber ||
+    port.pnpId ||
+    port.locationId
+  )
 }
 
 onMounted(() => {
@@ -380,35 +426,50 @@ const handleMenuClick = (command: string) => {
 
 /* 串口卡片样式 */
 .serial-port-card {
+  width: 100%;
+  max-width: none;
+  align-self: stretch;
+  box-sizing: border-box;
   padding: 0 !important;
   margin-top: 6px;
   min-height: auto !important;
 }
 
 .serial-port-card :deep(.el-card__body) {
-  padding: 8px 12px !important;
-  overflow-x: hidden;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  min-height: 56px;
+  padding: 8px 10px !important;
+  overflow: hidden;
 }
 
 .serial-port-content {
+  position: relative;
   display: flex;
+  width: 100%;
   justify-content: space-between;
   align-items: center;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .serial-port-left {
   flex: 1;
   min-width: 0;
-  overflow-x: hidden;
+  overflow: hidden;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 8px;
 }
 
 .serial-port-info {
   flex: 1;
   min-width: 0;
+}
+
+.serial-port-device {
+  min-width: 0;
+  overflow: hidden;
 }
 
 .serial-port-row {
@@ -422,7 +483,6 @@ const handleMenuClick = (command: string) => {
   height: 8px;
   border-radius: 50%;
   flex-shrink: 0;
-  margin-top: 6px;
 }
 
 .serial-port-left .connection-dot.connected {
@@ -434,20 +494,31 @@ const handleMenuClick = (command: string) => {
 }
 
 .serial-port-right {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  right: -2px;
+  transform: translateY(-50%);
   display: flex;
   align-items: center;
   opacity: 0;
-  transition: opacity 0.2s ease;
-  flex-shrink: 0;
+  visibility: hidden;
+  pointer-events: none;
+  padding-left: 14px;
+  background: linear-gradient(90deg, transparent 0, var(--sidebar-card-bg) 14px);
+  transition: opacity 0.2s ease, visibility 0.2s ease;
 }
 
 .serial-port-card:hover .serial-port-right {
   opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
 .serial-port-btn {
   padding: 4px 8px !important;
   font-size: 12px !important;
+  background-color: transparent !important;
 }
 
 .disconnect-btn {
@@ -472,6 +543,31 @@ const handleMenuClick = (command: string) => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.serial-friendly-name {
+  display: block;
+  color: var(--sidebar-remark);
+  font-size: 12px;
+  font-weight: normal;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.port-detail-tooltip {
+  max-width: 360px;
+  font-size: 12px;
+  line-height: 1.8;
+}
+
+.port-detail-row {
+  overflow-wrap: anywhere;
+}
+
+.port-detail-label {
+  color: var(--text-muted, #aaa);
 }
 
 .serial-port-type {

--- a/src/renderer/src/composables/app/useConnectionSidebar.ts
+++ b/src/renderer/src/composables/app/useConnectionSidebar.ts
@@ -17,6 +17,8 @@ export function useConnectionSidebar() {
   const sidebarWidth = ref(320)
   const serialPortExpanded = ref(true)
   const showPortType = ref(true)
+  const showSerialPortFriendlyName = ref(true)
+  const showSerialPortDetails = ref(false)
 
   const connectionGroupExpanded = ref<Record<string, boolean>>({
     telnet: true,
@@ -57,7 +59,18 @@ export function useConnectionSidebar() {
   const filteredSerialPorts = computed(() => {
     if (!searchKeyword.value) return serialPorts.value
     const keyword = searchKeyword.value.toLowerCase()
-    return serialPorts.value.filter((port) => port.path.toLowerCase().includes(keyword))
+    return serialPorts.value.filter((port) =>
+      [
+        port.path,
+        port.friendlyName,
+        port.manufacturer,
+        port.vendorId,
+        port.productId,
+        port.serialNumber,
+        port.pnpId,
+        port.locationId
+      ].some((value) => value?.toLowerCase().includes(keyword))
+    )
   })
 
   const connectionGroups = computed(() => {
@@ -123,6 +136,8 @@ export function useConnectionSidebar() {
       }
       const settings = await window.storageApi.getSettings()
       showPortType.value = settings.showPortType ?? true
+      showSerialPortFriendlyName.value = settings.showSerialPortFriendlyName ?? true
+      showSerialPortDetails.value = settings.showSerialPortDetails ?? false
     } catch (error) {
       console.error(t('common.loadFailed'), error)
     }
@@ -171,6 +186,8 @@ export function useConnectionSidebar() {
     sidebarWidth,
     serialPortExpanded,
     showPortType,
+    showSerialPortFriendlyName,
+    showSerialPortDetails,
     connectionGroupExpanded,
     filteredSerialPorts,
     connectionGroups,

--- a/src/renderer/src/locales/lang/en-US.json
+++ b/src/renderer/src/locales/lang/en-US.json
@@ -102,6 +102,10 @@
     "addNew": "Add New",
     "showPortType": "Show Port Type",
     "showPortTypeDesc": "Show type labels in port list (Virtual, USB, Bluetooth)",
+    "showFriendlyName": "Show Device Friendly Name",
+    "showFriendlyNameDesc": "Show the system-provided device name below the COM port",
+    "showPortDetails": "Show Device Details",
+    "showPortDetailsDesc": "Show manufacturer, VID/PID, serial number, and device ID on hover",
     "atLeastOneRate": "At least one baud rate must be kept",
     "invalidBaudRate": "Please enter a valid baud rate",
     "rateExists": "This baud rate already exists"
@@ -241,7 +245,11 @@
     "virtual": "Virtual Port",
     "usb": "USB",
     "bluetooth": "Bluetooth",
-    "noType": "Unknown"
+    "noType": "Unknown",
+    "friendlyName": "Friendly Name",
+    "manufacturer": "Manufacturer",
+    "serialNumber": "Serial Number",
+    "locationId": "Location ID"
   },
   "tabs": {
     "disconnectAll": "Disconnect All",

--- a/src/renderer/src/locales/lang/zh-CN.json
+++ b/src/renderer/src/locales/lang/zh-CN.json
@@ -102,6 +102,10 @@
     "addNew": "新增",
     "showPortType": "显示串口类型",
     "showPortTypeDesc": "在串口列表中显示类型标签（虚拟串口、USB、蓝牙）",
+    "showFriendlyName": "显示设备友好名称",
+    "showFriendlyNameDesc": "在 COM 号下方显示系统提供的设备名称",
+    "showPortDetails": "显示设备详细信息",
+    "showPortDetailsDesc": "鼠标悬停时显示制造商、VID/PID、序列号和设备 ID",
     "atLeastOneRate": "至少保留一个波特率",
     "invalidBaudRate": "请输入有效的波特率",
     "rateExists": "该波特率已存在"
@@ -241,7 +245,11 @@
     "virtual": "虚拟串口",
     "usb": "USB",
     "bluetooth": "蓝牙",
-    "noType": "无类型"
+    "noType": "无类型",
+    "friendlyName": "设备名称",
+    "manufacturer": "制造商",
+    "serialNumber": "序列号",
+    "locationId": "位置 ID"
   },
   "tabs": {
     "disconnectAll": "断开全部",

--- a/tests/e2e/serial-port-display.spec.ts
+++ b/tests/e2e/serial-port-display.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '@playwright/test'
+import { launchApp, closeApp, invokeStorage } from './helpers'
+
+test.describe('串口设备信息显示', () => {
+  test('按默认设置显示友好名称，并保持卡片布局可用', async () => {
+    const { app, page, userDataDir } = await launchApp()
+    try {
+      const settings = (await invokeStorage(app, 'getSettings')) as Record<string, unknown>
+      expect(settings.showSerialPortFriendlyName).toBe(true)
+      expect(settings.showSerialPortDetails).toBe(false)
+
+      await app.evaluate(({ ipcMain }) => {
+        ipcMain.removeHandler('list-serial-ports')
+        ipcMain.handle('list-serial-ports', () => [
+          {
+            path: 'COM4',
+            friendlyName: 'USB-Enhanced-SERIAL-A CH344 (COM4)',
+            manufacturer: 'WCH',
+            vendorId: '1A86',
+            productId: '55D5',
+            serialNumber: 'CH344-A',
+            pnpId: 'USB\\VID_1A86&PID_55D5\\CH344-A',
+            locationId: 'Port_#0001.Hub_#0002'
+          }
+        ])
+      })
+
+      await page
+        .locator('.connection-group')
+        .first()
+        .locator('.section-header .icon-text-button')
+        .click()
+      const card = page.locator('.serial-port-card').filter({ hasText: 'COM4' })
+      await expect(card).toBeVisible()
+      await expect(card.locator('.serial-friendly-name')).toHaveText('USB-Enhanced-SERIAL-A CH344')
+
+      const initialLayout = await card.evaluate((element) => {
+        const action = element.querySelector<HTMLElement>('.serial-port-right')!
+        const left = element.querySelector<HTMLElement>('.serial-port-left')!
+        const dot = element.querySelector<HTMLElement>('.connection-dot')!.getBoundingClientRect()
+        const content = element
+          .querySelector<HTMLElement>('.serial-port-content')!
+          .getBoundingClientRect()
+        return {
+          cardWidth: element.getBoundingClientRect().width,
+          actionPosition: getComputedStyle(action).position,
+          actionVisibility: getComputedStyle(action).visibility,
+          actionOpacity: getComputedStyle(action).opacity,
+          leftOverflowY: getComputedStyle(left).overflowY,
+          centerOffset: Math.abs(dot.top + dot.height / 2 - (content.top + content.height / 2))
+        }
+      })
+      expect(initialLayout.cardWidth).toBeLessThanOrEqual(250)
+      expect(initialLayout.actionPosition).toBe('absolute')
+      expect(initialLayout.actionVisibility).toBe('hidden')
+      expect(initialLayout.actionOpacity).toBe('0')
+      expect(initialLayout.leftOverflowY).toBe('hidden')
+      expect(initialLayout.centerOffset).toBeLessThanOrEqual(1)
+
+      await card.hover()
+      await expect(card.locator('.serial-port-right')).toHaveCSS('visibility', 'visible')
+
+      await page.evaluate(() => {
+        window.dispatchEvent(
+          new CustomEvent('settings-updated', {
+            detail: {
+              showSerialPortFriendlyName: false,
+              showSerialPortDetails: true
+            }
+          })
+        )
+      })
+      await expect(card.locator('.serial-friendly-name')).toHaveCount(0)
+      await expect(card.locator('.serial-port-left')).toHaveCSS('overflow-y', 'hidden')
+      const compactCardHeight = await card.evaluate(
+        (element) => element.getBoundingClientRect().height
+      )
+      expect(compactCardHeight).toBeGreaterThanOrEqual(56)
+      await card.locator('.serial-port-device').hover()
+      await expect(page.locator('.port-detail-tooltip')).toContainText('CH344-A')
+      await expect(page.locator('.port-detail-tooltip')).toContainText('1A86/55D5')
+    } finally {
+      await closeApp(app, userDataDir)
+    }
+  })
+})

--- a/tests/unit/SettingsStorage.test.ts
+++ b/tests/unit/SettingsStorage.test.ts
@@ -32,6 +32,8 @@ describe('SettingsStorage', () => {
       const settings = storage.getSettings()
       expect(settings.supportedBaudRates).toEqual([9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600, 1500000])
       expect(settings.showPortType).toBe(true)
+      expect(settings.showSerialPortFriendlyName).toBe(true)
+      expect(settings.showSerialPortDetails).toBe(false)
     })
 
     it('返回语法高亮默认设置', () => {

--- a/tests/unit/useConnectionSidebar.test.ts
+++ b/tests/unit/useConnectionSidebar.test.ts
@@ -33,7 +33,18 @@ function filterConnections(connections: any[], keyword: string): any[] {
 function filterSerialPorts(ports: any[], keyword: string): any[] {
   if (!keyword) return ports
   const lower = keyword.toLowerCase()
-  return ports.filter((port) => port.path.toLowerCase().includes(lower))
+  return ports.filter((port) =>
+    [
+      port.path,
+      port.friendlyName,
+      port.manufacturer,
+      port.vendorId,
+      port.productId,
+      port.serialNumber,
+      port.pnpId,
+      port.locationId
+    ].some((value) => value?.toLowerCase().includes(lower))
+  )
 }
 
 function groupConnections(connections: any[]): Record<string, any[]> {
@@ -137,9 +148,9 @@ describe('filterConnections', () => {
 
 describe('filterSerialPorts', () => {
   const ports = [
-    { path: 'COM1', manufacturer: 'USB' },
-    { path: 'COM2', manufacturer: 'USB' },
-    { path: 'COM55', manufacturer: 'Virtual' },
+    { path: 'COM1', manufacturer: 'WCH', friendlyName: 'USB-Enhanced-SERIAL-A CH344' },
+    { path: 'COM2', manufacturer: 'FTDI', serialNumber: 'FT123', vendorId: '0403', productId: '6001' },
+    { path: 'COM55', manufacturer: 'Virtual', pnpId: 'ROOT\\PORTS\\VIRTUAL55' },
   ]
 
   it('should return all ports when keyword is empty', () => {
@@ -154,6 +165,17 @@ describe('filterSerialPorts', () => {
 
   it('should be case-insensitive', () => {
     expect(filterSerialPorts(ports, 'com55')).toHaveLength(1)
+  })
+
+  it('should filter by friendly name and manufacturer', () => {
+    expect(filterSerialPorts(ports, 'ch344')).toHaveLength(1)
+    expect(filterSerialPorts(ports, 'ftdi')).toHaveLength(1)
+  })
+
+  it('should filter by device identifiers', () => {
+    expect(filterSerialPorts(ports, 'FT123')).toHaveLength(1)
+    expect(filterSerialPorts(ports, '0403')).toHaveLength(1)
+    expect(filterSerialPorts(ports, 'virtual55')).toHaveLength(1)
   })
 
   it('should return empty for no match', () => {


### PR DESCRIPTION
## 背景

目前串口列表主要显示 COM 端口号。当系统中连接了多个 USB 转串口设备时，仅凭 COM 编号较难快速识别具体设备。

此 PR 完成 #259，为串口列表增加系统友好名称和设备详细信息显示，同时改善串口卡片的布局与交互。

Closes #259

## 主要改动

### 1. 增加串口显示设置

在“设置 → 串口 COM 设置”中增加两个独立开关：

- 显示设备友好名称
  - 默认开启
  - 在 COM 端口号下方显示系统提供的设备名称
- 显示设备详细信息
  - 默认关闭
  - 开启后可通过鼠标悬停查看完整设备信息

原有“显示串口类型”设置保持不变。

设置通过现有设置存储接口持久化，并为旧版本配置提供兼容默认值。

### 2. 显示系统友好名称

串口卡片支持在 COM 端口号下方显示系统提供的友好名称，例如：

- USB Serial Port
- USB-Enhanced-SERIAL-A CH344
- USB-SERIAL CH340

如果系统友好名称末尾已经包含 `(COMx)`，界面会自动移除重复的端口号，避免出现类似：

`USB Serial Port (COM4) / COM4`

### 3. 显示设备详细信息

开启“显示设备详细信息”后，鼠标悬停在串口设备区域可查看：

- 友好名称
- 制造商
- VID/PID
- 序列号
- PnP ID
- Location ID

没有详细信息的设备不会显示空白提示框。

### 4. 扩展串口搜索

串口搜索不再只匹配 COM 端口号，同时支持搜索：

- 友好名称
- 制造商
- VID/PID
- 序列号
- PnP ID
- Location ID

这使得多串口设备场景下可以直接按芯片型号、厂商或序列号查找设备。

### 5. 优化串口卡片布局

- 卡片宽度自动适应侧栏宽度
- 统一有无友好名称时的基础高度
- 修复友好名称关闭后出现异常拖动/滚动控件的问题
- 连接状态圆点在整个卡片内容区域垂直居中
- 友好名称过长时使用省略号显示
- 串口类型标签和设备名称不会相互挤压
- 调整卡片横向间距，使整体宽度更自然

### 6. 优化连接按钮显示

- 连接/断开按钮默认透明
- 非悬停状态不再占用或遮挡设备文字
- 只有鼠标悬停时按钮才可见并响应点击
- 按钮区域使用渐变背景，避免文字和操作按钮重叠

## 国际化

补充中文和英文文案，包括：

- 友好名称设置
- 设备详细信息设置
- 制造商
- 序列号
- Location ID 等设备字段

## 测试

已完成：

- [x] Node TypeScript 类型检查
- [x] Vue TypeScript 类型检查
- [x] `SettingsStorage` 单元测试
- [x] `useConnectionSidebar` 单元测试
- [x] 39 项相关单元测试全部通过
- [x] Electron Vite 生产构建通过

另外增加了串口显示相关的 Playwright E2E 测试用例，覆盖：

- 默认显示友好名称
- 关闭友好名称
- 开启设备详情
- 串口卡片布局
- 连接按钮悬停显示

## 兼容性

- 不修改串口连接协议
- 不修改串口枚举接口
- 不影响虚拟串口、Telnet、FTP 等其他连接类型
- 旧配置中缺少新字段时会自动使用默认值