### PR TITLE
优化跨平台串口名称显示

### DIFF
--- a/src/renderer/src/features/connections/ConnectionSidebar.vue
+++ b/src/renderer/src/features/connections/ConnectionSidebar.vue
@@ -61,7 +61,7 @@
                         </template>
                         <div class="serial-port-device" tabindex="0">
                           <div class="serial-port-row">
-                            <span class="conn-name">{{ port.path }}</span>
+                            <span class="conn-name" :title="port.path">{{ port.path }}</span>
                             <span v-if="showPortType" class="serial-port-type">
                               <el-tag v-if="port.type === 'virtual'" type="info" size="small" effect="dark">{{ t('sidebar.virtual') }}</el-tag>
                               <el-tag v-else-if="port.type === 'usb'" type="success" size="small" effect="dark">{{ t('sidebar.usb') }}</el-tag>
@@ -360,8 +360,8 @@ const handleMenuClick = (command: string) => {
   font-weight: 600;
   color: var(--text-secondary);
   display: inline-block;
-  width: 80px;
-  flex-shrink: 0;
+  min-width: 0;
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/renderer/src/features/connections/ConnectionSidebar.vue
+++ b/src/renderer/src/features/connections/ConnectionSidebar.vue
@@ -61,7 +61,7 @@
                         </template>
                         <div class="serial-port-device" tabindex="0">
                           <div class="serial-port-row">
-                            <span class="conn-name" :title="port.path">{{ port.path }}</span>
+                            <span class="conn-name" :title="port.path">{{ getSerialPortDisplayName(port.path) }}</span>
                             <span v-if="showPortType" class="serial-port-type">
                               <el-tag v-if="port.type === 'virtual'" type="info" size="small" effect="dark">{{ t('sidebar.virtual') }}</el-tag>
                               <el-tag v-else-if="port.type === 'usb'" type="success" size="small" effect="dark">{{ t('sidebar.usb') }}</el-tag>
@@ -193,6 +193,7 @@ import { useI18n } from 'vue-i18n'
 import SearchInput from '../../components/SearchInput.vue'
 import { TOOLTIP_SHOW_AFTER } from '../../utils/constants'
 import SidebarLayout from '../../foundation/shell/SidebarLayout.vue'
+import { getSerialPortDisplayName } from './useConnectionSidebar'
 
 const { t } = useI18n()
 

--- a/src/renderer/src/features/connections/useConnectionSidebar.ts
+++ b/src/renderer/src/features/connections/useConnectionSidebar.ts
@@ -8,6 +8,12 @@ import { ElMessage } from 'element-plus'
 
 export type SerialPortType = 'virtual' | 'usb' | 'bluetooth' | 'none'
 
+export function getSerialPortDisplayName(path: string): string {
+  const fileName = path.replace(/\\/g, '/').split('/').pop() || path
+  // macOS 的 cu./tty. 表示设备访问模式，不是设备名称；Linux 的 ttyUSB/ttyACM 则保留类型信息。
+  return fileName.replace(/^(?:cu|tty)\./i, '')
+}
+
 export function useConnectionSidebar() {
   const { t } = useI18n()
   const connections = ref<any[]>([])

--- a/src/renderer/src/features/connections/useConnectionSidebar.ts
+++ b/src/renderer/src/features/connections/useConnectionSidebar.ts
@@ -9,9 +9,7 @@ import { ElMessage } from 'element-plus'
 export type SerialPortType = 'virtual' | 'usb' | 'bluetooth' | 'none'
 
 export function getSerialPortDisplayName(path: string): string {
-  const fileName = path.replace(/\\/g, '/').split('/').pop() || path
-  // macOS 的 cu./tty. 表示设备访问模式，不是设备名称；Linux 的 ttyUSB/ttyACM 则保留类型信息。
-  return fileName.replace(/^(?:cu|tty)\./i, '')
+  return path.replace(/\\/g, '/').split('/').pop() || path
 }
 
 export function useConnectionSidebar() {

--- a/tests/unit/useConnectionSidebar.test.ts
+++ b/tests/unit/useConnectionSidebar.test.ts
@@ -3,6 +3,7 @@
  * 测试：串口类型解析、搜索过滤、连接分组
  */
 import { describe, it, expect } from 'vitest'
+import { getSerialPortDisplayName } from '../../src/renderer/src/features/connections/useConnectionSidebar'
 
 // Extract pure functions from useConnectionSidebar for testing
 function parseSerialPortType(port: { path: string; friendlyName?: string; manufacturer?: string; pnpId?: string }): 'virtual' | 'usb' | 'bluetooth' | 'none' {
@@ -56,6 +57,20 @@ function groupConnections(connections: any[]): Record<string, any[]> {
   })
   return groups
 }
+
+describe('getSerialPortDisplayName', () => {
+  it.each([
+    ['COM3', 'COM3'],
+    ['\\\\.\\COM10', 'COM10'],
+    ['/dev/ttyUSB0', 'ttyUSB0'],
+    ['/dev/ttyACM0', 'ttyACM0'],
+    ['/dev/rfcomm0', 'rfcomm0'],
+    ['/dev/cu.usbserial-1410', 'usbserial-1410'],
+    ['/dev/tty.usbmodem1101', 'usbmodem1101']
+  ])('formats %s as %s', (path, expected) => {
+    expect(getSerialPortDisplayName(path)).toBe(expected)
+  })
+})
 
 describe('parseSerialPortType', () => {
   it('should return virtual for ports with virtual in name', () => {

--- a/tests/unit/useConnectionSidebar.test.ts
+++ b/tests/unit/useConnectionSidebar.test.ts
@@ -65,8 +65,8 @@ describe('getSerialPortDisplayName', () => {
     ['/dev/ttyUSB0', 'ttyUSB0'],
     ['/dev/ttyACM0', 'ttyACM0'],
     ['/dev/rfcomm0', 'rfcomm0'],
-    ['/dev/cu.usbserial-1410', 'usbserial-1410'],
-    ['/dev/tty.usbmodem1101', 'usbmodem1101']
+    ['/dev/cu.usbserial-1410', 'cu.usbserial-1410'],
+    ['/dev/tty.usbmodem1101', 'tty.usbmodem1101']
   ])('formats %s as %s', (path, expected) => {
     expect(getSerialPortDisplayName(path)).toBe(expected)
   })


### PR DESCRIPTION
## 背景

组件迁移到 `features/connections` 后，串口名称使用固定 `80px` 宽度，即使侧边栏仍有可用空间也会过早显示省略号。Linux/macOS 的串口路径还包含较长的系统路径前缀，进一步压缩了有效设备名称。

## 本次变更

- 串口名称从固定 `80px` 改为弹性宽度，充分使用类型标签之外的剩余空间。
- 增加跨平台显示名称转换，仅缩短显示文本，不修改实际连接路径：
  - Windows：`COM3` 保持 `COM3`，`\\.\COM10` 显示为 `COM10`
  - Linux：`/dev/ttyUSB0` 显示为 `ttyUSB0`，保留 `ttyUSB/ttyACM/ttyAMA/ttyS` 等驱动类型信息
  - macOS：仅移除 `/dev/`，`/dev/cu.usbserial-1410` 显示为 `cu.usbserial-1410`；保留 `cu.`/`tty.` 以区分系统提供的成对设备节点
- 空间不足时仍保留省略号，悬浮可查看完整原始路径。
- 补充 Windows、Linux、macOS 路径转换单元测试。

## 兼容性

连接、断开、备注和搜索仍使用原始 `port.path`，本次只改变侧边栏显示文本。

## 验证

- `npm run typecheck`
- `vitest run tests/unit/useConnectionSidebar.test.ts tests/unit/useSidebarResize.test.ts`
- 2 个测试文件、37 个测试通过

## 自动化署名

本次代码修改、测试验证和 PR 内容整理由 OpenCode（GPT-5.6 Sol）自动完成，人工确认后提交。