### PR TITLE
fix: 修复连接启动与重连竞态

### DIFF
--- a/src/main/ipc/connectors/DirectConnector.ts
+++ b/src/main/ipc/connectors/DirectConnector.ts
@@ -21,6 +21,9 @@ export default class DirectConnector {
 
   // 直连模式客户端实例（每个 session 独立实例，避免 onData/onClose 回调覆盖）
   private directClients: Map<string, DirectClient> = new Map()
+  private pendingStarts: Map<string, Set<Promise<object>>> = new Map()
+  private startQueues: Map<string, Promise<void>> = new Map()
+  private generations: Map<string, number> = new Map()
 
   constructor(stateManager: ConnectionStateManager) {
     this.stateManager = stateManager
@@ -35,24 +38,26 @@ export default class DirectConnector {
 
   // ============ 回调工厂 ============
 
-  private createOnData(sessionId: string) {
+  private createOnData(sessionId: string, client: DirectClient) {
     return (dataObj: { data: string; timestamp: string }) => {
+      if (this.directClients.get(sessionId) !== client) return
       const isHex = this.stateManager.getReceiveHex(sessionId)
       // HEX 转换已下沉到 BufferLineSplitter.decodeBuffer() 中完成，此处不再重复转换
       this.stateManager.sendDataToRenderer(sessionId, dataObj.data, dataObj.timestamp, isHex)
     }
   }
 
-  private createOnClose(sessionId: string): () => void {
+  private createOnClose(sessionId: string, client: DirectClient): () => void {
     return () => {
+      if (this.directClients.get(sessionId) !== client) return
       this.stateManager.cleanupOnClose(sessionId)
       this.directClients.delete(sessionId)
     }
   }
 
-  private createOnLog(sessionId: string) {
+  private createOnLog(sessionId: string, client: DirectClient) {
     return (logStr: string, timestamp: string) => {
-      if (!this.logger) return
+      if (!this.logger || this.directClients.get(sessionId) !== client) return
       const finalLog = this.stateManager.buildLogContent(sessionId, logStr, timestamp)
       this.logger.appendToConnLog(finalLog, sessionId)
     }
@@ -62,20 +67,47 @@ export default class DirectConnector {
 
   async startConnection(conn: any, connInfo: ConnectionInfo): Promise<object> {
     const sessionId = conn.sessionId
+    const generation = (this.generations.get(sessionId) ?? 0) + 1
+    this.generations.set(sessionId, generation)
+    const previousQueue = this.startQueues.get(sessionId) ?? Promise.resolve()
+    let startPromise!: Promise<object>
+    startPromise = previousQueue.then(async () => {
+      if ((this.generations.get(sessionId) ?? 0) !== generation) {
+        return { success: false, message: 'Direct mode start cancelled' }
+      }
 
-    const ComClient = (await import('../../protocol/ComClient')).default
-    const TelnetClient = (await import('../../protocol/TelnetClient')).default
+      const ComClient = (await import('../../protocol/ComClient')).default
+      const TelnetClient = (await import('../../protocol/TelnetClient')).default
+      const ClientClass = conn.connectionType === 'com' ? ComClient : TelnetClient
+      const client = new ClientClass()
+      this.directClients.set(sessionId, client)
 
-    const ClientClass = conn.connectionType === 'com' ? ComClient : TelnetClient
-    const client = new ClientClass()
-    this.directClients.set(sessionId, client)
+      const result = await client.start(
+        connInfo,
+        this.createOnData(sessionId, client),
+        this.createOnClose(sessionId, client),
+        this.createOnLog(sessionId, client)
+      )
 
-    return await client.start(
-      connInfo,
-      this.createOnData(sessionId),
-      this.createOnClose(sessionId),
-      this.createOnLog(sessionId)
-    )
+      if ((this.generations.get(sessionId) ?? 0) !== generation || this.directClients.get(sessionId) !== client) {
+        await client.disconnect(sessionId)
+        if (this.directClients.get(sessionId) === client) this.directClients.delete(sessionId)
+        return { success: false, message: 'Direct mode start cancelled' }
+      }
+      return result
+    })
+    const pending = this.pendingStarts.get(sessionId) ?? new Set<Promise<object>>()
+    pending.add(startPromise)
+    this.pendingStarts.set(sessionId, pending)
+    const queue = startPromise.then(() => undefined, () => undefined)
+    this.startQueues.set(sessionId, queue)
+    try {
+      return await startPromise
+    } finally {
+      pending.delete(startPromise)
+      if (pending.size === 0) this.pendingStarts.delete(sessionId)
+      if (this.startQueues.get(sessionId) === queue) this.startQueues.delete(sessionId)
+    }
   }
 
   async sendData(conn: any, command: string): Promise<object> {
@@ -88,10 +120,15 @@ export default class DirectConnector {
   }
 
   async stopConnection(conn: any): Promise<object> {
-    const client = this.directClients.get(conn.sessionId)
+    const sessionId = conn.sessionId
+    this.generations.set(sessionId, (this.generations.get(sessionId) ?? 0) + 1)
+    const pending = this.pendingStarts.get(sessionId)
+    const activeStart = pending?.values().next().value as Promise<object> | undefined
+    await activeStart?.catch(() => undefined)
+    const client = this.directClients.get(sessionId)
     if (!client) return { success: true }
-    const result = await client.disconnect(conn.sessionId)
-    this.directClients.delete(conn.sessionId)
+    const result = await client.disconnect(sessionId)
+    if (this.directClients.get(sessionId) === client) this.directClients.delete(sessionId)
     return result || { success: true }
   }
 

--- a/src/main/pool/WorkerPool.ts
+++ b/src/main/pool/WorkerPool.ts
@@ -46,6 +46,8 @@ interface WorkerEntry {
   worker: Worker
   sessionId: string
   alive: boolean
+  starting: boolean
+  cancelStart?: () => void
   pendingRequests: Map<string, {
     resolve: (value: any) => void
     reject: (reason: any) => void
@@ -58,6 +60,10 @@ export default class WorkerPool {
 
   // sessionId -> WorkerEntry 映射（每个连接一个 Worker）
   private workerMap = new Map<string, WorkerEntry>()
+
+  // 同一 session 的启动依次执行，不同 session 之间互不阻塞
+  private startOperations = new Map<string, Promise<unknown>>()
+  private startVersions = new Map<string, number>()
 
   private requestCounter: number = 0
 
@@ -112,6 +118,7 @@ export default class WorkerPool {
       worker,
       sessionId,
       alive: true,
+      starting: true,
       pendingRequests: new Map()
     }
 
@@ -133,12 +140,12 @@ export default class WorkerPool {
       entry.alive = false
 
       // 如果 Worker 异常退出（非主动 disconnect），通知外部连接已断开
-      if (this.workerMap.has(sessionId)) {
+      if (this.workerMap.get(sessionId) === entry) {
         this.onCloseCallback?.(sessionId)
+        this.workerMap.delete(sessionId)
       }
 
       this.rejectAllPending(entry, new Error(`Worker exited`))
-      this.workerMap.delete(sessionId)
     })
 
     this.workerMap.set(sessionId, entry)
@@ -149,13 +156,15 @@ export default class WorkerPool {
    * 处理 Worker 发来的消息
    */
   private handleWorkerMessage(entry: WorkerEntry, msg: WorkerToMainMessage): void {
+    const isCurrentEntry = this.workerMap.get(entry.sessionId) === entry
+
     switch (msg.type) {
       case 'ready':
         logger.info(`[WorkerPool] Worker [${entry.sessionId}] is ready`)
         break
 
       case 'data':
-        if (msg.sessionId && msg.displayData !== undefined) {
+        if (isCurrentEntry && msg.sessionId === entry.sessionId && msg.displayData !== undefined) {
           this.onDataCallback?.(
             msg.sessionId,
             msg.displayData,
@@ -166,7 +175,7 @@ export default class WorkerPool {
         break
 
       case 'log':
-        if (msg.sessionId && msg.logStr !== undefined) {
+        if (isCurrentEntry && msg.sessionId === entry.sessionId && msg.logStr !== undefined) {
           this.onLogCallback?.(
             msg.sessionId,
             msg.logStr,
@@ -176,9 +185,9 @@ export default class WorkerPool {
         break
 
       case 'close':
-        if (msg.sessionId) {
+        if (isCurrentEntry && msg.sessionId === entry.sessionId) {
           // 连接关闭后，终止 Worker 回收资源
-          this.terminateWorker(msg.sessionId)
+          void this.terminateEntry(entry)
           this.onCloseCallback?.(msg.sessionId)
         }
         break
@@ -235,13 +244,28 @@ export default class WorkerPool {
       throw new Error(`Worker for session ${sessionId} not found or not alive`)
     }
 
+    return this.sendToEntry(entry, msg, timeoutMs)
+  }
+
+  /**
+   * 发送消息到指定 WorkerEntry，避免启动期间重新查 map 后误发给新一代 Worker
+   */
+  private async sendToEntry(
+    entry: WorkerEntry,
+    msg: MainToWorkerMessage,
+    timeoutMs: number = 30000
+  ): Promise<any> {
+    if (!entry.alive) {
+      throw new Error(`Worker for session ${entry.sessionId} not found or not alive`)
+    }
+
     return new Promise((resolve, reject) => {
       const requestId = this.generateRequestId()
       msg.requestId = requestId
 
       const timer = setTimeout(() => {
         entry.pendingRequests.delete(requestId)
-        reject(new Error(`Request timeout: ${msg.type} (sessionId: ${sessionId})`))
+        reject(new Error(`Request timeout: ${msg.type} (sessionId: ${entry.sessionId})`))
       }, timeoutMs)
 
       entry.pendingRequests.set(requestId, { resolve, reject, timer })
@@ -256,7 +280,25 @@ export default class WorkerPool {
     const entry = this.workerMap.get(sessionId)
     if (!entry) return
 
-    if (entry.alive) {
+    await this.terminateEntry(entry)
+  }
+
+  /**
+   * 只回收传入的一代 Worker；旧异步流程不得删除或终止 map 中的新 Worker
+   */
+  private async terminateEntry(entry: WorkerEntry): Promise<void> {
+    const { sessionId } = entry
+    const wasAlive = entry.alive
+
+    entry.alive = false
+    entry.cancelStart?.()
+    entry.cancelStart = undefined
+    if (this.workerMap.get(sessionId) === entry) {
+      this.workerMap.delete(sessionId)
+    }
+    this.rejectAllPending(entry, new Error(`Worker terminated`))
+
+    if (wasAlive) {
       try {
         entry.worker.postMessage({ type: 'shutdown', sessionId })
         // 给 Worker 一点时间清理
@@ -265,7 +307,6 @@ export default class WorkerPool {
       } catch { /* ignore */ }
     }
 
-    this.workerMap.delete(sessionId)
     logger.info(`[WorkerPool] Worker [${sessionId}] terminated`)
   }
 
@@ -276,6 +317,32 @@ export default class WorkerPool {
    */
   async startConnection(connInfo: any, connectionType: string): Promise<{ success: boolean; message?: string; connId?: string }> {
     const sessionId = String(connInfo.sessionId)
+    const startVersion = this.startVersions.get(sessionId) || 0
+    const previous = this.startOperations.get(sessionId) || Promise.resolve()
+    const operation = previous
+      .catch(() => undefined)
+      .then(() => this.startConnectionSerial(sessionId, connInfo, connectionType, startVersion))
+
+    this.startOperations.set(sessionId, operation)
+    try {
+      return await operation
+    } finally {
+      if (this.startOperations.get(sessionId) === operation) {
+        this.startOperations.delete(sessionId)
+      }
+    }
+  }
+
+  private async startConnectionSerial(
+    sessionId: string,
+    connInfo: any,
+    connectionType: string,
+    startVersion: number
+  ): Promise<{ success: boolean; message?: string; connId?: string }> {
+
+    if ((this.startVersions.get(sessionId) || 0) !== startVersion) {
+      return { success: false, message: 'Start cancelled by stop' }
+    }
 
     // 如果已有同 sessionId 的 Worker，先清理
     if (this.workerMap.has(sessionId)) {
@@ -287,40 +354,54 @@ export default class WorkerPool {
     // 等待 Worker ready（带超时保护）
     try {
       await new Promise<void>((resolve, reject) => {
+        const cleanup = () => {
+          clearTimeout(timer)
+          entry.worker.off('message', onReady)
+          entry.worker.off('error', onError)
+          entry.worker.off('exit', onExit)
+        }
         const onReady = (msg: WorkerToMainMessage) => {
           if (msg.type === 'ready' && msg.sessionId === sessionId) {
-            entry.worker.off('message', onReady)
-            entry.worker.off('error', onError)
-            entry.worker.off('exit', onExit)
+            cleanup()
+            entry.cancelStart = undefined
             resolve()
           }
         }
         const onError = (err: Error) => {
-          entry.worker.off('message', onReady)
-          entry.worker.off('error', onError)
-          entry.worker.off('exit', onExit)
+          cleanup()
           reject(new Error(`Worker error before ready: ${err.message}`))
         }
         const onExit = (code: number) => {
-          entry.worker.off('message', onReady)
-          entry.worker.off('error', onError)
-          entry.worker.off('exit', onExit)
+          cleanup()
           reject(new Error(`Worker exited with code ${code} before ready`))
         }
+        const timer = setTimeout(() => {
+          cleanup()
+          reject(new Error(`Worker ready timeout (sessionId: ${sessionId})`))
+        }, 30000)
         entry.worker.on('message', onReady)
         entry.worker.once('error', onError)
         entry.worker.once('exit', onExit)
+        entry.cancelStart = () => {
+          cleanup()
+          reject(new Error('Start cancelled by stop'))
+        }
       })
     } catch (err: any) {
       logger.error(`[WorkerPool] Worker [${sessionId}] failed to become ready:`, err.message)
-      this.workerMap.delete(sessionId)
+      await this.terminateEntry(entry)
       return { success: false, message: err.message }
+    }
+
+    if ((this.startVersions.get(sessionId) || 0) !== startVersion || !entry.alive) {
+      await this.terminateEntry(entry)
+      return { success: false, message: 'Start cancelled by stop' }
     }
 
     logger.info(`[WorkerPool] Starting connection ${sessionId} in dedicated Worker`)
 
     try {
-      const result = await this.sendToWorker(sessionId, {
+      const result = await this.sendToEntry(entry, {
         type: 'start',
         sessionId,
         connInfo,
@@ -329,7 +410,7 @@ export default class WorkerPool {
 
       if (!result.success) {
         // 启动失败，回收 Worker
-        await this.terminateWorker(sessionId)
+        await this.terminateEntry(entry)
       }
 
       return {
@@ -339,8 +420,10 @@ export default class WorkerPool {
       }
     } catch (err: any) {
       logger.error(`[WorkerPool] startConnection failed:`, err.message)
-      await this.terminateWorker(sessionId)
+      await this.terminateEntry(entry)
       return { success: false, message: err.message }
+    } finally {
+      entry.starting = false
     }
   }
 
@@ -370,17 +453,24 @@ export default class WorkerPool {
    */
   async stopConnection(sessionId: string, _connectionType: string): Promise<{ success: boolean; message?: string }> {
     const normalizedSessionId = String(sessionId)
-    // 先通知 Worker 主动断开
-    try {
-      await this.sendToWorker(normalizedSessionId, {
-        type: 'stop',
-        sessionId: normalizedSessionId
-      }, 5000) // 断开超时设为 5 秒
-    } catch {
-      // 超时或失败都继续 terminate
+    this.startVersions.set(normalizedSessionId, (this.startVersions.get(normalizedSessionId) || 0) + 1)
+
+    const entry = this.workerMap.get(normalizedSessionId)
+    if (entry && !entry.starting) {
+      // 已完成启动的 Worker 先收到 stop；启动中的 Worker 直接取消并回收。
+      try {
+        await this.sendToEntry(entry, {
+          type: 'stop',
+          sessionId: normalizedSessionId
+        }, 5000)
+      } catch {
+        // 超时或失败都继续 terminate
+      }
     }
 
-    await this.terminateWorker(normalizedSessionId)
+    if (entry) {
+      await this.terminateEntry(entry)
+    }
     return { success: true }
   }
 

--- a/src/renderer/src/features/terminal/ComTerminal.vue
+++ b/src/renderer/src/features/terminal/ComTerminal.vue
@@ -238,6 +238,18 @@ const crcMethod = ref<string>('CRC-16/MODBUS')
 
 let removeMountedCloseListener: (() => void) | null = null
 let removeDataListener: (() => void) | null = null
+let connectGeneration = 0
+let isDisposed = false
+let retryTimer: ReturnType<typeof setTimeout> | null = null
+
+const cancelPendingConnect = () => {
+  connectGeneration++
+  isConnecting.value = false
+  if (retryTimer) {
+    clearTimeout(retryTimer)
+    retryTimer = null
+  }
+}
 
 // 串口参数
 const baudRates = ref<number[]>([]) // 从全局设置加载
@@ -563,26 +575,37 @@ const deleteBaudRate = async (rate: number) => {
 }
 
 const handleConnect = async () => {
+  if (isDisposed || isConnecting.value || isConnected.value) return
+
+  const generation = ++connectGeneration
+  const connection = {
+    connectionType: 'com',
+    comName: props.connection.comName,
+    baudRate: baudRate.value,
+    dataBits: dataBits.value,
+    stopBits: stopBits.value,
+    parity: parity.value,
+    name: props.connection.name,
+    sessionId: props.connection.sessionId,
+    encoding: encoding.value,
+    readTimeout: readTimeout.value,
+    writeTimeout: writeTimeout.value,
+    receiveHex: hexDisplayMode.value
+  }
   isConnecting.value = true
   unifiedTerminalRef.value?.appendToTerminal(`\n${t('comTerminal.connecting', { port: props.connection.comName })}\n`)
 
   try {
-    const result = await window.connectApi.startConnect({
-      connectionType: 'com',
-      comName: props.connection.comName,
-      baudRate: baudRate.value,
-      dataBits: dataBits.value,
-      stopBits: stopBits.value,
-      parity: parity.value,
-      name: props.connection.name,
-      sessionId: props.connection.sessionId,
-      encoding: encoding.value,
-      readTimeout: readTimeout.value,
-      writeTimeout: writeTimeout.value,
-      receiveHex: hexDisplayMode.value
-    })
+    const result = await window.connectApi.startConnect(connection)
 
     if (result.success) {
+      if (isDisposed || generation !== connectGeneration) {
+        isConnecting.value = false
+        await window.connectApi.stopConnect(connection).catch((error) => {
+          console.error(t('comTerminal.connectionClosed'), error)
+        })
+        return
+      }
       currentSessionId.value = String(props.connection.sessionId)
       isConnected.value = true
       isConnecting.value = false
@@ -613,6 +636,7 @@ const handleConnect = async () => {
       throw err
     }
   } catch (error) {
+    if (isDisposed || generation !== connectGeneration) return
     isConnecting.value = false
     const err = error as Error & { code?: string }
     unifiedTerminalRef.value?.appendToTerminal(`\n${t('comTerminal.connectFailed')}: ${err.message}\n`)
@@ -647,6 +671,7 @@ const offerSerialPermissionFix = async () => {
 
 const handleClose = async () => {
   preventAutoReconnect.value = true
+  cancelPendingConnect()
   terminalCleanup()
   // 清理数据监听器
   if (removeDataListener) {
@@ -754,9 +779,11 @@ defineExpose({
 })
 
 onMounted(async () => {
+  isDisposed = false
   preventAutoReconnect.value = false
   await loadBaudRates()
   await loadComSettings()
+  if (isDisposed) return
 
   nextTick(() => {
     unifiedTerminalRef.value?.setHexDisplayMode?.(hexDisplayMode.value)
@@ -786,6 +813,9 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  const shouldStopConnection = isConnected.value || isConnecting.value
+  isDisposed = true
+  cancelPendingConnect()
   terminalCleanup()
   window.removeEventListener('settings-updated', handleSettingsUpdated)
   if (removeDataListener) {
@@ -797,7 +827,7 @@ onUnmounted(() => {
     removeMountedCloseListener = null
   }
 
-  if (isConnected.value) {
+  if (shouldStopConnection) {
     window.connectApi
       .stopConnect({
         connectionType: 'com',

--- a/src/renderer/src/features/terminal/TelnetTerminal.vue
+++ b/src/renderer/src/features/terminal/TelnetTerminal.vue
@@ -32,7 +32,7 @@ const { t } = useI18n()
 import UnifiedTerminal from './UnifiedTerminal.vue'
 import { fromRawConnection } from '../../features/connections/protocol'
 import { useTerminal } from './useTerminal'
-import { recvDisplayText } from './useTerminalDisplayText'
+import { formatReceivedData, recvDisplayText } from './useTerminalDisplayText'
 
 const MAX_RETRY_COUNT = 1000
 const RETRY_INTERVAL_MS = 3000
@@ -62,11 +62,13 @@ const isConnecting = ref(false)
 const unifiedTerminalRef = ref<InstanceType<typeof UnifiedTerminal>>()
 
 let retryCount = 0
-let retryTimer: NodeJS.Timeout | null = null
+let retryTimer: ReturnType<typeof setTimeout> | null = null
 const stopRetry = ref(false)
 let preventAutoReconnect = false
 let removeDataListener: (() => void) | null = null
 let removeCloseListener: (() => void) | null = null
+let connectGeneration = 0
+let connectAttemptQueue = Promise.resolve()
 
 // 获取原始 connection id
 const getOriginalConnectionId = (): number | undefined => {
@@ -129,25 +131,58 @@ const terminal = useTerminal({
 
 const { openLogFolder, openLogFile, saveLogFile, cleanup: terminalCleanup } = terminal
 
-const handleClose = async () => {
-  stopRetry.value = true
+const clearRetryTimer = () => {
   if (retryTimer) {
     clearTimeout(retryTimer)
     retryTimer = null
   }
+}
+
+const getStopConnectionPayload = () => {
+  const stopConn: any = {
+    connectionType: props.connection.connectionType,
+    sessionId: props.connection.sessionId
+  }
+  if (props.connection.connectionType === 'telnet') {
+    stopConn.host = props.connection.host
+    stopConn.port = props.connection.port
+  }
+  return stopConn
+}
+
+// This primitive must stay queue-free because it is also used from a queued start task.
+const stopConnectionDirect = async () => {
+  await window.connectApi.stopConnect(getStopConnectionPayload())
+}
+
+const enqueueConnectionTask = (task: () => Promise<void>) => {
+  const queuedTask = connectAttemptQueue.catch(() => undefined).then(task)
+  connectAttemptQueue = queuedTask
+  return queuedTask
+}
+
+const stopConnection = async () => {
+  // Cancel a pending backend start immediately, then wait for its renderer task
+  // to observe the generation change before a later generation can start.
+  await stopConnectionDirect()
+  await connectAttemptQueue.catch(() => undefined)
+}
+
+const cancelConnectLifecycle = () => {
+  connectGeneration++
+  stopRetry.value = true
+  clearRetryTimer()
+  isConnecting.value = false
+}
+
+const handleClose = async () => {
+  preventAutoReconnect = true
+  cancelConnectLifecycle()
   // 先清理监听器，防止 onConnectClose 回调触发重连提示
   cleanup()
   unifiedTerminalRef.value?.appendToTerminal(`\n连接已关闭\n`)
   try {
-    const stopConn: any = {
-      connectionType: props.connection.connectionType,
-      sessionId: props.connection.sessionId
-    }
-    if (props.connection.connectionType === 'telnet') {
-      stopConn.host = props.connection.host
-      stopConn.port = props.connection.port
-    }
-    await window.connectApi.stopConnect(stopConn)
+    await stopConnection()
   } catch (error) {
     console.error('Failed to close connection:', error)
   }
@@ -167,19 +202,45 @@ const cleanup = () => {
   isConnected.value = false
 }
 
-const handleReconnect = () => {
+const handleReconnect = async () => {
+  const shouldStopConnection = isConnected.value
+  cancelConnectLifecycle()
+  const reconnectGeneration = connectGeneration
+  cleanup()
   preventAutoReconnect = false
   stopRetry.value = false
   terminal.totalTxSize = 0
   terminal.totalRxSize = 0
   unifiedTerminalRef.value?.resetRxTx()
   unifiedTerminalRef.value?.appendToTerminal(`\n正在重新连接...\n`)
+  if (shouldStopConnection) {
+    try {
+      await stopConnection()
+    } catch (error) {
+      console.error('Failed to stop connection before reconnecting:', error)
+    }
+  }
+  if (reconnectGeneration !== connectGeneration || preventAutoReconnect) return
   connect()
 }
 
 const reconnect = () => handleReconnect()
 
-const handleTelnetClose = (_connId: number) => {
+const scheduleRetry = (callback: () => void, delay: number, generation: number) => {
+  clearRetryTimer()
+  retryTimer = setTimeout(() => {
+    retryTimer = null
+    if (generation !== connectGeneration || stopRetry.value || preventAutoReconnect) return
+    callback()
+  }, delay)
+}
+
+const handleTelnetClose = (_sessionId: string | number, generation: number) => {
+  if (generation !== connectGeneration) return
+  connectGeneration++
+  const reconnectGeneration = connectGeneration
+  clearRetryTimer()
+  isConnecting.value = false
   cleanup()
   if (preventAutoReconnect) {
     unifiedTerminalRef.value?.appendToTerminal(`\n连接已关闭\n`)
@@ -193,29 +254,51 @@ const handleTelnetClose = (_connId: number) => {
   ElMessage.info(t('terminal.reconnecting'))
   unifiedTerminalRef.value?.appendToTerminal(`\n连接已关闭，将在${RETRY_INTERVAL_MS / 1000}秒后尝试重连...\n`)
   if (!stopRetry.value) {
-    setTimeout(connect, 1000)
+    scheduleRetry(connect, RETRY_INTERVAL_MS, reconnectGeneration)
   }
 }
 
-let currentConnId = 0
+const registerConnectionListeners = (generation: number) => {
+  removeDataListener?.()
+  removeCloseListener?.()
+
+  const sessionId = String(props.connection.sessionId)
+  removeDataListener = window.connectApi.onRecvData((data) => {
+    if (generation !== connectGeneration || String(data.connId) !== sessionId) return
+    terminal.totalRxSize += data.data.length
+    unifiedTerminalRef.value?.updateRxBytes(data.data.length)
+    const recvLabel = recvDisplayText.value ? `${recvDisplayText.value} ` : ''
+    const displayText = formatReceivedData(`${recvLabel}${data.data}`, terminal.showTimestamp.value, data.timestamp)
+    unifiedTerminalRef.value?.appendToTerminal(displayText)
+  })
+
+  removeCloseListener = window.connectApi.onConnectClose((closedSessionId) => {
+    if (String(closedSessionId) !== sessionId) return
+    handleTelnetClose(closedSessionId, generation)
+  })
+}
 
 const connect = async () => {
   if (preventAutoReconnect) {
     return
   }
+  clearRetryTimer()
+  const generation = ++connectGeneration
   stopRetry.value = false
   retryCount = 0
   isConnected.value = false
   isConnecting.value = true
-  currentConnId = 0
   terminal.totalRxSize = 0
   terminal.totalTxSize = 0
 
   const attemptConnect = async () => {
-    if (stopRetry.value) {
-      isConnecting.value = false
+    if (generation !== connectGeneration || stopRetry.value || preventAutoReconnect) {
+      if (generation === connectGeneration) isConnecting.value = false
       return
     }
+
+    // A retry may have been superseded while it was waiting in the timer queue.
+    clearRetryTimer()
 
     try {
       // 通过 connectionId 发起连接，后端从存储中解密密码
@@ -231,9 +314,19 @@ const connect = async () => {
           password: undefined
         }))
       )
+
+      if (generation !== connectGeneration || stopRetry.value || preventAutoReconnect) {
+        if (result.success) {
+          try {
+            await stopConnectionDirect()
+          } catch (error) {
+            console.error('Failed to clean up stale connection:', error)
+          }
+        }
+        return
+      }
+
       if (result.success) {
-        terminalCleanup()
-        currentConnId = result.connId
         isConnected.value = true
         isConnecting.value = false
 
@@ -252,31 +345,7 @@ const connect = async () => {
           { logTimestamp: terminal.showTimestamp.value }
         )
 
-        // 清理旧监听器，防止重复注册
-        if (removeDataListener) {
-          removeDataListener()
-          removeDataListener = null
-        }
-        if (removeCloseListener) {
-          removeCloseListener()
-          removeCloseListener = null
-        }
 
-        removeDataListener = window.connectApi.onRecvData((data) => {
-          if (data.connId !== currentConnId) return
-          terminal.totalRxSize += data.data.length
-          unifiedTerminalRef.value?.updateRxBytes(data.data.length)
-          const prefix = terminal.showTimestamp.value && data.timestamp ? `[${data.timestamp}] ` : ''
-          const recvLabel = recvDisplayText.value ? `${recvDisplayText.value} ` : ''
-          const displayText = `${prefix}${recvLabel}${data.data}\n`
-          unifiedTerminalRef.value?.appendToTerminal(displayText)
-        })
-
-        removeCloseListener = window.connectApi.onConnectClose((connId) => {
-          // 只处理自己连接的断开事件
-          if (String(connId) !== String(props.connection.sessionId)) return
-          handleTelnetClose(connId)
-        })
         const successMsg = props.connection.ftpMode === 'server'
           ? `\nserver started, retry count: ${retryCount + 1}\n`
           : `\nconnect success, retry count: ${retryCount + 1}\n`
@@ -286,20 +355,35 @@ const connect = async () => {
         throw new Error(result.message || '连接失败')
       }
     } catch (error) {
+      if (generation !== connectGeneration || stopRetry.value || preventAutoReconnect) return
       retryCount++
       const errMsg = (error as Error).message
       unifiedTerminalRef.value?.appendToTerminal(`\nconnect failed: (${retryCount}/${MAX_RETRY_COUNT}): ${errMsg}\n`)
       if (retryCount < MAX_RETRY_COUNT && !stopRetry.value) {
-        retryTimer = setTimeout(attemptConnect, RETRY_INTERVAL_MS)
+        scheduleRetry(runAttempt, RETRY_INTERVAL_MS, generation)
       } else if (retryCount >= MAX_RETRY_COUNT) {
         isConnecting.value = false
+        // Do not leave the failed generation's callbacks registered indefinitely.
+        cleanup()
         emit('onClose')
         if (typeof props.onClose === 'function') props.onClose()
       }
     }
   }
 
-  await attemptConnect()
+  const runAttempt = async () => {
+    // A stale successful start must finish stopping before a newer generation
+    // starts with the same sessionId, otherwise its cleanup could stop the new one.
+    await enqueueConnectionTask(async () => {
+      if (generation !== connectGeneration || stopRetry.value || preventAutoReconnect) return
+      // Register only after the previous generation has cleaned itself up, but
+      // before this generation starts, so neither stale close nor early data wins.
+      registerConnectionListeners(generation)
+      await attemptConnect()
+    })
+  }
+
+  await runAttempt()
 }
 
 const handleSend = async (command: string, _originalInput?: string) => {
@@ -372,20 +456,12 @@ defineExpose({
   reconnect,
   cleanup: () => {
     preventAutoReconnect = true
-    stopRetry.value = true
-    if (retryTimer) {
-      clearTimeout(retryTimer)
-      retryTimer = null
-    }
+    cancelConnectLifecycle()
     cleanup()
   },
   preventAutoReconnect: () => {
     preventAutoReconnect = true
-    stopRetry.value = true
-    if (retryTimer) {
-      clearTimeout(retryTimer)
-      retryTimer = null
-    }
+    cancelConnectLifecycle()
   },
   getFontFamily: () => {
     const unifiedFont = unifiedTerminalRef.value?.getFontFamily?.()
@@ -400,12 +476,11 @@ defineExpose({
 onBeforeUnmount(() => {
   // 组件销毁时确保一切清理干净：停止重试、移除监听器
   preventAutoReconnect = true
-  stopRetry.value = true
-  if (retryTimer) {
-    clearTimeout(retryTimer)
-    retryTimer = null
-  }
+  cancelConnectLifecycle()
   cleanup()
+  stopConnection().catch((error) => {
+    console.error('Failed to disconnect on unmount:', error)
+  })
 })
 
 onMounted(() => {

--- a/src/renderer/src/features/terminal/useTerminalDisplayText.ts
+++ b/src/renderer/src/features/terminal/useTerminalDisplayText.ts
@@ -7,6 +7,19 @@ const DEFAULT_RECV_DISPLAY_TEXT = ''
 export const sendDisplayText = ref<string>(DEFAULT_SEND_DISPLAY_TEXT)
 export const recvDisplayText = ref<string>(DEFAULT_RECV_DISPLAY_TEXT)
 
+/** Adds the receive batch timestamp to every line while preserving blank lines. */
+export function formatReceivedData(content: string, showTimestamp: boolean, timestamp?: string): string {
+  if (!showTimestamp || !timestamp) return `${content}\n`
+  if (!content) return '\n'
+
+  const prefix = `[${timestamp}] `
+  const lines = content.split(/\r\n|\n|\r/)
+  // split() adds one structural empty item for a trailing line break; the caller already appends the display newline.
+  if (/(?:\r\n|\n|\r)$/.test(content)) lines.pop()
+  if (lines.length === 1 && lines[0] === '') return '\n'
+  return `${lines.map(line => `${prefix}${line}`).join('\n')}\n`
+}
+
 /** Loads persisted terminal display labels. */
 export async function loadTerminalDisplayText(): Promise<void> {
   try {

--- a/tests/unit/DirectConnector.test.ts
+++ b/tests/unit/DirectConnector.test.ts
@@ -43,7 +43,7 @@ import DirectConnector from '../../src/main/ipc/connectors/DirectConnector'
 import ConnectionStateManager from '../../src/main/ipc/connectors/ConnectionStateManager'
 import ProtocolLogger from '../../src/main/utils/ProtocolLogger'
 
-function makeConn(overrides: Partial<{ connectionType: string; sessionId: string; host: string; port: number; comName: string }> = {}): any {
+function makeConn(overrides: Partial<{ connectionType: string; sessionId: string; host: string; port: number; comName: string; receiveHex: boolean }> = {}): any {
   return {
     connectionType: 'com',
     sessionId: 's1',
@@ -104,6 +104,26 @@ describe('DirectConnector', () => {
 
       expect(result).toEqual({ success: true, message: 'connected' })
     })
+
+    it('should serialize two starts for the same session', async () => {
+      let resolveFirst: ((result: object) => void) | undefined
+      mockComStart.mockImplementationOnce((() => new Promise<object>((resolve) => {
+        resolveFirst = resolve
+      })) as any)
+
+      const { dc } = createDirectConnector()
+      const conn = makeConn({ sessionId: 's-serial' })
+      const first = dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-serial' })
+      await vi.waitFor(() => expect(resolveFirst).toBeDefined())
+      const second = dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-serial' })
+
+      expect(mockComStart).toHaveBeenCalledTimes(1)
+      resolveFirst?.({ success: true })
+      await expect(first).resolves.toEqual({ success: false, message: 'Direct mode start cancelled' })
+      await expect(second).resolves.toEqual({ success: true, message: 'connected' })
+      expect(mockComStart).toHaveBeenCalledTimes(2)
+      expect(mockComDisconnect).toHaveBeenCalledTimes(1)
+    })
   })
 
   // ============ sendData ============
@@ -131,6 +151,46 @@ describe('DirectConnector', () => {
   // ============ stopConnection ============
 
   describe('stopConnection', () => {
+    it('should wait for a pending start before disconnecting', async () => {
+      let resolveStart: ((result: object) => void) | undefined
+      mockComStart.mockImplementationOnce((() => new Promise<object>((resolve) => {
+        resolveStart = resolve
+      })) as any)
+
+      const { dc } = createDirectConnector()
+      const conn = makeConn({ connectionType: 'com', sessionId: 's-pending' })
+      const startPromise = dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-pending' })
+      await vi.waitFor(() => expect(resolveStart).toBeDefined())
+      const stopPromise = dc.stopConnection(conn)
+
+      expect(mockComDisconnect).not.toHaveBeenCalled()
+      resolveStart?.({ success: true })
+      await expect(stopPromise).resolves.toEqual({ success: true })
+      await startPromise
+      expect(mockComDisconnect).toHaveBeenCalledWith('s-pending')
+    })
+
+    it('should cancel queued starts and wait for the active start', async () => {
+      let resolveStart: ((result: object) => void) | undefined
+      mockComStart.mockImplementationOnce((() => new Promise<object>((resolve) => {
+        resolveStart = resolve
+      })) as any)
+
+      const { dc } = createDirectConnector()
+      const conn = makeConn({ sessionId: 's-cancel-queued' })
+      const first = dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-cancel-queued' })
+      await vi.waitFor(() => expect(resolveStart).toBeDefined())
+      const queued = dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-cancel-queued' })
+      const stop = dc.stopConnection(conn)
+
+      expect(mockComStart).toHaveBeenCalledTimes(1)
+      resolveStart?.({ success: true })
+      await expect(stop).resolves.toEqual({ success: true })
+      await expect(queued).resolves.toEqual({ success: false, message: 'Direct mode start cancelled' })
+      await first
+      expect(mockComDisconnect).toHaveBeenCalledTimes(1)
+    })
+
     it('should disconnect and clean up client', async () => {
       const { dc } = createDirectConnector()
       const conn = makeConn({ connectionType: 'com', sessionId: 's1' })
@@ -190,6 +250,23 @@ describe('DirectConnector', () => {
       expect(sendSpy).toHaveBeenCalledWith('s1', 'hello', '12:00:00', false)
     })
 
+    it('ignores data and log callbacks from a replaced client', async () => {
+      const { dc, sm, logger } = createDirectConnector()
+      const sendSpy = vi.spyOn(sm, 'sendDataToRenderer')
+      const conn = makeConn({ sessionId: 's-replaced' })
+
+      await dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-replaced' })
+      const oldOnData = mockComStart.mock.calls[0][1]
+      const oldOnLog = mockComStart.mock.calls[0][3]
+      await dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-replaced' })
+
+      oldOnData({ data: 'stale', timestamp: '12:00:00' })
+      oldOnLog('stale log', '12:00:00')
+
+      expect(sendSpy).not.toHaveBeenCalled()
+      expect(logger.appendToConnLog).not.toHaveBeenCalled()
+    })
+
     it('onData should pass through data directly when receiveHex is true (HEX conversion moved to BufferLineSplitter)', async () => {
       const { dc, sm } = createDirectConnector()
       const sendSpy = vi.spyOn(sm, 'sendDataToRenderer')
@@ -220,6 +297,21 @@ describe('DirectConnector', () => {
       // After close, client should be removed from map
       const result = await dc.sendData(conn, 'test')
       expect(result.success).toBe(false)
+    })
+
+    it('should not let an old client onClose delete the new client', async () => {
+      const { dc, sm } = createDirectConnector()
+      const cleanupSpy = vi.spyOn(sm, 'cleanupOnClose')
+      const conn = makeConn({ sessionId: 's-generations' })
+
+      await dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-generations' })
+      const oldOnClose = mockComStart.mock.calls[0][2]
+      await dc.stopConnection(conn)
+      await dc.startConnection(conn, { host: '', port: 0, username: '', password: '', sessionId: 's-generations' })
+
+      oldOnClose()
+      expect(cleanupSpy).toHaveBeenCalledTimes(0)
+      await expect(dc.sendData(conn, 'test')).resolves.toEqual({ success: true })
     })
 
     it('onLog should call logger.appendToConnLog with proper format', async () => {

--- a/tests/unit/WorkerPool.test.ts
+++ b/tests/unit/WorkerPool.test.ts
@@ -1,16 +1,25 @@
 /**
  * WorkerPool 测试
- * 测试 Worker 线程池的核心逻辑（纯逻辑测试，不实际创建 Worker 线程）
+ * 测试 Worker 线程池的核心逻辑（使用可控 Worker mock）
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const workerState = vi.hoisted(() => ({
+  instances: [] as any[]
+}))
 
 // Mock worker_threads
 vi.mock('worker_threads', () => ({
   Worker: class {
     _listeners: Map<string, Function[]> = new Map()
     _terminated: boolean = false
+    messages: any[] = []
+    workerData: any
 
-    constructor(_path: string, _options: any) {}
+    constructor(_path: string, options: any) {
+      this.workerData = options.workerData
+      workerState.instances.push(this)
+    }
 
     on(event: string, handler: Function) {
       if (!this._listeners.has(event)) this._listeners.set(event, [])
@@ -19,7 +28,11 @@ vi.mock('worker_threads', () => ({
     }
 
     once(event: string, handler: Function) {
-      this.on(event, handler)
+      const wrapper = (...args: any[]) => {
+        this.off(event, wrapper)
+        handler(...args)
+      }
+      this.on(event, wrapper)
       return this
     }
 
@@ -30,7 +43,15 @@ vi.mock('worker_threads', () => ({
       return this
     }
 
-    postMessage(_msg: any) {}
+    postMessage(msg: any) {
+      this.messages.push(msg)
+    }
+
+    emit(event: string, ...args: any[]) {
+      for (const handler of [...(this._listeners.get(event) || [])]) {
+        handler(...args)
+      }
+    }
 
     async terminate() {
       this._terminated = true
@@ -51,13 +72,46 @@ vi.mock('../../src/main/ipc/IpcAppLogger', () => ({
 
 import WorkerPool from '../../src/main/pool/WorkerPool'
 
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function startRequest(worker: any): any {
+  return worker.messages.find((message: any) => message.type === 'start')
+}
+
+function makeReady(worker: any): void {
+  worker.emit('message', {
+    type: 'ready',
+    sessionId: worker.workerData.sessionId
+  })
+}
+
+function resolveStart(worker: any, success = true): void {
+  const request = startRequest(worker)
+  worker.emit('message', {
+    type: 'start-result',
+    sessionId: worker.workerData.sessionId,
+    requestId: request.requestId,
+    success,
+    connId: `${worker.workerData.sessionId}-connection`
+  })
+}
+
 describe('WorkerPool', () => {
   let pool: WorkerPool
 
   beforeEach(() => {
+    vi.useFakeTimers()
+    workerState.instances.length = 0
     // Reset singleton
     ;(WorkerPool as any).sInstance = null
     pool = WorkerPool.getInstance()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   describe('getInstance', () => {
@@ -113,22 +167,205 @@ describe('WorkerPool', () => {
     })
   })
 
-  describe('startConnection - validation', () => {
-    it('should require sessionId in connInfo', async () => {
-      const connInfo = {
-        host: 'localhost',
-        port: 23,
-        username: '',
-        password: '',
-        // missing sessionId
-      }
+  describe('startConnection concurrency', () => {
+    it('serializes two starts for the same session and sends start to its own entry', async () => {
+      const first = pool.startConnection({ sessionId: 'same', host: 'first' }, 'telnet')
+      await flushPromises()
+      const firstWorker = workerState.instances[0]
 
-      // Worker creation will fail because the mock Worker doesn't emit 'ready'
-      // We just verify the interface accepts the parameters
-      const promise = pool.startConnection(connInfo, 'telnet')
-      // This will likely timeout because Worker mock doesn't emit ready
-      // We just verify it doesn't throw synchronously
-      expect(promise).toBeInstanceOf(Promise)
+      makeReady(firstWorker)
+      await flushPromises()
+      const second = pool.startConnection({ sessionId: 'same', host: 'second' }, 'telnet')
+      await flushPromises()
+
+      expect(workerState.instances).toHaveLength(1)
+      expect(startRequest(firstWorker).connInfo.host).toBe('first')
+
+      resolveStart(firstWorker)
+      await expect(first).resolves.toMatchObject({ success: true })
+      await vi.advanceTimersByTimeAsync(200)
+      await flushPromises()
+
+      const secondWorker = workerState.instances[1]
+      expect(secondWorker).toBeDefined()
+      expect(firstWorker._terminated).toBe(true)
+      expect(startRequest(secondWorker)).toBeUndefined()
+
+      makeReady(secondWorker)
+      await flushPromises()
+      expect(startRequest(secondWorker).connInfo.host).toBe('second')
+      expect(firstWorker.messages.filter((message: any) => message.type === 'start')).toHaveLength(1)
+
+      resolveStart(secondWorker)
+      await expect(second).resolves.toMatchObject({ success: true })
+    })
+
+    it('starts different sessions in parallel', async () => {
+      const first = pool.startConnection({ sessionId: 'a' }, 'telnet')
+      const second = pool.startConnection({ sessionId: 'b' }, 'telnet')
+      await flushPromises()
+
+      expect(workerState.instances).toHaveLength(2)
+      const [workerA, workerB] = workerState.instances
+      makeReady(workerA)
+      makeReady(workerB)
+      await flushPromises()
+
+      expect(startRequest(workerA)).toBeDefined()
+      expect(startRequest(workerB)).toBeDefined()
+      resolveStart(workerA)
+      resolveStart(workerB)
+
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        expect.objectContaining({ success: true }),
+        expect.objectContaining({ success: true })
+      ])
+    })
+
+    it('cancels a start while it is waiting for the worker', async () => {
+      const start = pool.startConnection({ sessionId: 'pending' }, 'telnet')
+      await flushPromises()
+      const worker = workerState.instances[0]
+
+      const stop = pool.stopConnection('pending', 'telnet')
+      await vi.advanceTimersByTimeAsync(200)
+      await expect(stop).resolves.toMatchObject({ success: true })
+      await expect(start).resolves.toMatchObject({
+        success: false,
+        message: 'Start cancelled by stop'
+      })
+      expect(worker._terminated).toBe(true)
+      expect(pool.getStatus().workerCount).toBe(0)
+    })
+
+    it('cancels a queued second start after stop', async () => {
+      const first = pool.startConnection({ sessionId: 'queued', generation: 1 }, 'telnet')
+      await flushPromises()
+      const worker = workerState.instances[0]
+      const second = pool.startConnection({ sessionId: 'queued', generation: 2 }, 'telnet')
+      const stop = pool.stopConnection('queued', 'telnet')
+
+      await vi.advanceTimersByTimeAsync(200)
+      await expect(stop).resolves.toMatchObject({ success: true })
+      await expect(first).resolves.toMatchObject({ success: false })
+      await expect(second).resolves.toMatchObject({
+        success: false,
+        message: 'Start cancelled by stop'
+      })
+      expect(workerState.instances).toHaveLength(1)
+      expect(worker._terminated).toBe(true)
+      expect(pool.getStatus().workerCount).toBe(0)
+    })
+
+    it('ignores close and exit cleanup from an old worker generation', async () => {
+      const first = pool.startConnection({ sessionId: 'same', generation: 1 }, 'telnet')
+      await flushPromises()
+      const oldWorker = workerState.instances[0]
+      makeReady(oldWorker)
+      await flushPromises()
+      resolveStart(oldWorker)
+      await first
+
+      const second = pool.startConnection({ sessionId: 'same', generation: 2 }, 'telnet')
+      await flushPromises()
+      await vi.advanceTimersByTimeAsync(200)
+      await flushPromises()
+      const newWorker = workerState.instances[1]
+      makeReady(newWorker)
+      await flushPromises()
+      resolveStart(newWorker)
+      await second
+
+      oldWorker.emit('message', { type: 'close', sessionId: 'same' })
+      oldWorker.emit('exit', 0)
+
+      expect(pool.getStatus()).toEqual({
+        workerCount: 1,
+        sessions: [{ sessionId: 'same', alive: true }]
+      })
+      expect(newWorker._terminated).toBe(false)
+    })
+
+    it('ignores data and log messages from an old worker generation', async () => {
+      const onData = vi.fn()
+      const onLog = vi.fn()
+      pool.setCallbacks(onData, onLog, vi.fn())
+
+      const first = pool.startConnection({ sessionId: 'messages', generation: 1 }, 'telnet')
+      await flushPromises()
+      const oldWorker = workerState.instances[0]
+      makeReady(oldWorker)
+      await flushPromises()
+      resolveStart(oldWorker)
+      await first
+
+      const second = pool.startConnection({ sessionId: 'messages', generation: 2 }, 'telnet')
+      await flushPromises()
+      await vi.advanceTimersByTimeAsync(200)
+      await flushPromises()
+      const newWorker = workerState.instances[1]
+      makeReady(newWorker)
+      await flushPromises()
+      resolveStart(newWorker)
+      await second
+
+      oldWorker.emit('message', {
+        type: 'data',
+        sessionId: 'messages',
+        displayData: 'old-data'
+      })
+      oldWorker.emit('message', {
+        type: 'log',
+        sessionId: 'messages',
+        logStr: 'old-log'
+      })
+      newWorker.emit('message', {
+        type: 'data',
+        sessionId: 'messages',
+        displayData: 'new-data'
+      })
+      newWorker.emit('message', {
+        type: 'log',
+        sessionId: 'messages',
+        logStr: 'new-log'
+      })
+
+      expect(onData).toHaveBeenCalledTimes(1)
+      expect(onData).toHaveBeenCalledWith('messages', 'new-data', '', false)
+      expect(onLog).toHaveBeenCalledTimes(1)
+      expect(onLog).toHaveBeenCalledWith('messages', 'new-log', '')
+    })
+
+    it('cleans up a worker when the start request times out', async () => {
+      const start = pool.startConnection({ sessionId: 'timeout' }, 'telnet')
+      await flushPromises()
+      const worker = workerState.instances[0]
+      makeReady(worker)
+      await flushPromises()
+
+      await vi.advanceTimersByTimeAsync(30200)
+
+      await expect(start).resolves.toMatchObject({
+        success: false,
+        message: expect.stringContaining('Request timeout: start')
+      })
+      expect(worker._terminated).toBe(true)
+      expect(pool.getStatus().workerCount).toBe(0)
+    })
+
+    it('cleans up a worker when start returns failure', async () => {
+      const start = pool.startConnection({ sessionId: 'failed' }, 'telnet')
+      await flushPromises()
+      const worker = workerState.instances[0]
+      makeReady(worker)
+      await flushPromises()
+      resolveStart(worker, false)
+
+      await vi.advanceTimersByTimeAsync(200)
+
+      await expect(start).resolves.toMatchObject({ success: false })
+      expect(worker._terminated).toBe(true)
+      expect(pool.getStatus().workerCount).toBe(0)
     })
   })
 

--- a/tests/unit/useTerminalDisplayText.test.ts
+++ b/tests/unit/useTerminalDisplayText.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { formatReceivedData } from '../../src/renderer/src/features/terminal/useTerminalDisplayText'
+
+describe('formatReceivedData', () => {
+  it.each([
+    ['first\nsecond', '[12:34:56] first\n[12:34:56] second\n'],
+    ['first\r\nsecond', '[12:34:56] first\n[12:34:56] second\n'],
+    ['first\rsecond', '[12:34:56] first\n[12:34:56] second\n']
+  ])('adds the receive batch timestamp to each line in %j', (content, expected) => {
+    expect(formatReceivedData(content, true, '12:34:56')).toBe(expected)
+  })
+
+  it('preserves blank lines when adding the batch timestamp', () => {
+    expect(formatReceivedData('first\r\n\r\nthird', true, '12:34:56')).toBe(
+      '[12:34:56] first\n[12:34:56] \n[12:34:56] third\n'
+    )
+  })
+
+  it('does not add a timestamp-only line for a trailing line ending', () => {
+    expect(formatReceivedData('first\r\n', true, '12:34:56')).toBe('[12:34:56] first\n')
+  })
+
+  it('preserves an intentional blank line before a trailing line ending', () => {
+    expect(formatReceivedData('first\n\n', true, '12:34:56')).toBe('[12:34:56] first\n[12:34:56] \n')
+  })
+
+  it('does not turn an empty batch into a timestamp-only line', () => {
+    expect(formatReceivedData('', true, '12:34:56')).toBe('\n')
+  })
+
+  it.each(['\n', '\r', '\r\n'])('does not turn a single line ending into a timestamp-only line: %j', content => {
+    expect(formatReceivedData(content, true, '12:34:56')).toBe('\n')
+  })
+
+  it('keeps content layout unchanged when timestamps are disabled', () => {
+    expect(formatReceivedData('first\r\n\rsecond', false, '12:34:56')).toBe('first\r\n\rsecond\n')
+  })
+
+  it('keeps the existing no-timestamp behavior when a timestamp is unavailable', () => {
+    expect(formatReceivedData('first\nsecond', true)).toBe('first\nsecond\n')
+  })
+})


### PR DESCRIPTION
## 问题

连接启动、断开与自动重连之间存在竞态：

1. 连接启动进行中点击断开/重连，挂起的启动完成后会把已断开的连接重新拉起
2. 过期连接的 `onConnectClose` / `onRecvData` 回调会串扰新连接（触发错误重连、写入脏数据）
3. 重试定时器在组件销毁后仍可能触发，访问已释放的资源

## 方案

**主进程**
- `DirectConnector` / `WorkerPool`：连接启动与停止按会话串行化，后到的停止能取消先到但未完成的启动

**渲染进程（ComTerminal / TelnetTerminal）**
- 引入 `connectGeneration` 代际机制：每次启动/关闭/重连递增代际，过期代际的回调与重试直接丢弃
- 重试定时器统一由 `scheduleRetry` / `clearRetryTimer` 管理
- 监听器统一在连接任务队列中注册（`enqueueConnectionTask`），确保上一代清理完成后新一代才开始
- 新增 `formatReceivedData` 统一接收数据的逐行时间戳格式化（供新的监听注册逻辑使用）

## 测试

- 新增/更新 `DirectConnector`、`WorkerPool`、`useTerminalDisplayText` 单元测试
- 全量单测 1249 个通过，typecheck 通过

---
> 本 PR 由 OpenCode (kimi-k3) 辅助整理与验证。