### PR TITLE
fix: 串口备注竞态修复 + 右键菜单编辑备注

### DIFF
--- a/src/renderer/src/App.vue
+++ b/src/renderer/src/App.vue
@@ -54,6 +54,7 @@
         @deleteConnection="deleteConnection"
         @sidebarMenuCommand="handleSidebarMenuCommand"
         @update:serialPortExpanded="(v) => serialPortExpanded = v"
+        @serialPortContextMenu="handleSerialPortContextMenu"
       />
 
       <!-- 侧边栏分隔条 -->
@@ -497,13 +498,18 @@ watch(connectionTabs, (tabs) => {
 const {
   showRemarkDialog, editingRemark, editingRemarkComName,
   serialRemarks,
-  loadAllSerialRemarks, openRemarkDialog, onRemarkDialogOpened, saveSerialRemark
+  loadAllSerialRemarks, openRemarkDialog, openSerialPortRemark, onRemarkDialogOpened, saveSerialRemark
 } = useSerialRemarks(comTerminalRefs)
 
 const openRemarkDialogHandler = async () => {
   if (!rightClickedTab.value?.comName) return
   await openRemarkDialog(rightClickedTab.value)
   hideTabMenu()
+}
+
+// 串口右键菜单处理
+const handleSerialPortContextMenu = async (data: { event: MouseEvent; port: any }) => {
+  await openSerialPortRemark(data.port.path)
 }
 
 // ---- 分屏操作 ----
@@ -845,7 +851,7 @@ const handleMergePanel = () => {
 */
 
 const saveSerialRemarkHandler = () => {
-  saveSerialRemark(rightClickedTab.value)
+  saveSerialRemark()
 }
 
 // ---- Connection Dialog ----

--- a/src/renderer/src/features/connections/ConnectionSidebar.vue
+++ b/src/renderer/src/features/connections/ConnectionSidebar.vue
@@ -34,6 +34,7 @@
                 v-for="port in filteredSerialPorts"
                 :key="port.path"
                 @dblclick="$emit('connectToSerialPort', port)"
+                @contextmenu.prevent="$emit('serialPortContextMenu', { event: $event, port })"
               >
                 <div class="serial-port-content">
                   <div class="serial-port-left">
@@ -224,6 +225,7 @@ const emit = defineEmits<{
   editCreateDialog: [conn: any]
   deleteConnection: [conn: any]
   sidebarMenuCommand: [command: string]
+  serialPortContextMenu: [data: { event: MouseEvent; port: SerialPortInfo }]
 }>()
 
 const showSidebarMenu = ref(false)
@@ -687,4 +689,3 @@ const handleMenuClick = (command: string) => {
   color: var(--menu-item-hover-color);
 }
 </style>
-

--- a/src/renderer/src/features/connections/useSerialRemarks.ts
+++ b/src/renderer/src/features/connections/useSerialRemarks.ts
@@ -4,8 +4,9 @@ import { ElMessage } from 'element-plus'
 
 /** Minimal COM terminal contract needed to keep serial remarks synchronized. */
 export interface ComTerminalRemarkRef {
+  getComName?: () => string
   getRemark?: () => string
-  updateRemark?: (remark: string) => Promise<void>
+  setRemark?: (remark: string) => void
 }
 
 /** Maintains persisted COM-port remarks for the SuperConnectX connection feature. */
@@ -16,9 +17,10 @@ export function useSerialRemarks(comTerminalRefs: Record<string, ComTerminalRema
   const editingRemarkComName = ref('')
   const serialRemarks = reactive<Record<string, string>>({})
   const remarkInputRef = ref<any>(null)
+  let openRequestId = 0
 
   const loadSerialRemark = async (comName: string): Promise<string> => {
-    if (serialRemarks[comName]) return serialRemarks[comName]
+    if (Object.hasOwn(serialRemarks, comName)) return serialRemarks[comName]
     try {
       const settings = await window.storageApi.getComSettings(comName)
       const remark = settings?.remark || ''
@@ -35,21 +37,37 @@ export function useSerialRemarks(comTerminalRefs: Record<string, ComTerminalRema
 
   const openRemarkDialog = async (tab: { comName?: string; id: string | number }) => {
     if (!tab.comName) return
-    editingRemarkComName.value = tab.comName
+    const comName = tab.comName
+    const requestId = ++openRequestId
+    editingRemarkComName.value = comName
     const terminal = comTerminalRefs[tab.id.toString()]
 
-    if (serialRemarks[tab.comName]) {
-      editingRemark.value = serialRemarks[tab.comName]
+    let remark: string
+    if (Object.hasOwn(serialRemarks, comName)) {
+      remark = serialRemarks[comName]
     } else if (terminal?.getRemark) {
-      editingRemark.value = terminal.getRemark() || ''
+      remark = terminal.getRemark() || ''
+      serialRemarks[comName] = remark
     } else {
       try {
-        const settings = await window.storageApi.getComSettings(tab.comName)
-        editingRemark.value = settings?.remark || ''
+        const settings = await window.storageApi.getComSettings(comName)
+        remark = settings?.remark || ''
+        serialRemarks[comName] = remark
       } catch {
-        editingRemark.value = ''
+        remark = ''
       }
     }
+    if (requestId !== openRequestId) return
+    editingRemark.value = remark
+    showRemarkDialog.value = true
+  }
+
+  const openSerialPortRemark = async (comName: string) => {
+    const requestId = ++openRequestId
+    editingRemarkComName.value = comName
+    const remark = Object.hasOwn(serialRemarks, comName) ? serialRemarks[comName] : await loadSerialRemark(comName)
+    if (requestId !== openRequestId) return
+    editingRemark.value = remark
     showRemarkDialog.value = true
   }
 
@@ -60,27 +78,25 @@ export function useSerialRemarks(comTerminalRefs: Record<string, ComTerminalRema
     })
   }
 
-  const saveSerialRemark = async (rightClickedTab?: { id: string | number; comName?: string } | null) => {
+  const saveSerialRemark = async (_rightClickedTab?: { id: string | number; comName?: string } | null) => {
     const comName = editingRemarkComName.value
     if (!comName) return
-    serialRemarks[comName] = editingRemark.value
-
-    const terminal = rightClickedTab ? comTerminalRefs[rightClickedTab.id.toString()] : undefined
-    if (terminal?.updateRemark) {
-      await terminal.updateRemark(editingRemark.value)
-      showRemarkDialog.value = false
-      return
-    }
+    const remark = editingRemark.value
 
     try {
       const currentSettings = await window.storageApi.getComSettings(comName)
-      await window.storageApi.saveComSettings(comName, { ...currentSettings, remark: editingRemark.value })
+      const saved = await window.storageApi.saveComSettings(comName, { ...currentSettings, remark })
+      if (saved === false) throw new Error('saveComSettings returned false')
+      serialRemarks[comName] = remark
+      for (const terminal of Object.values(comTerminalRefs)) {
+        if (terminal.getComName?.() === comName) terminal.setRemark?.(remark)
+      }
+      if (editingRemarkComName.value === comName) showRemarkDialog.value = false
     } catch (error) {
       console.error(t('dialog.remarkSaveFailed'), error)
       ElMessage.error(t('dialog.remarkSaveFailed'))
     }
-    showRemarkDialog.value = false
   }
 
-  return { showRemarkDialog, editingRemark, editingRemarkComName, serialRemarks, remarkInputRef, loadSerialRemark, loadAllSerialRemarks, openRemarkDialog, onRemarkDialogOpened, saveSerialRemark }
+  return { showRemarkDialog, editingRemark, editingRemarkComName, serialRemarks, remarkInputRef, loadSerialRemark, loadAllSerialRemarks, openRemarkDialog, openSerialPortRemark, onRemarkDialogOpened, saveSerialRemark }
 }

--- a/src/renderer/src/features/terminal/ComTerminal.vue
+++ b/src/renderer/src/features/terminal/ComTerminal.vue
@@ -479,6 +479,11 @@ const updateRemark = async (newRemark: string) => {
   emit('remarkUpdated', { comName: props.connection.comName, remark: newRemark })
 }
 
+const setRemark = (newRemark: string) => {
+  remark.value = newRemark
+  emit('remarkUpdated', { comName: props.connection.comName, remark: newRemark })
+}
+
 // 通知后端更新日志时间戳配置
 const notifyLogTimestampToBackend = async (showTs: boolean) => {
   if (!isConnected.value) return
@@ -740,8 +745,10 @@ defineExpose({
   disconnect: handleClose,
   isConnected: isConnectedValue,
   preventAutoReconnect: () => { preventAutoReconnect.value = true },
+  getComName: () => props.connection.comName,
   getRemark: () => remark.value,
   updateRemark,
+  setRemark,
   handleFontChange,
   getFontFamily: () => {
     const unifiedFont = unifiedTerminalRef.value?.getFontFamily?.()

--- a/tests/unit/useSerialRemarks.test.ts
+++ b/tests/unit/useSerialRemarks.test.ts
@@ -1,95 +1,113 @@
-/**
- * useSerialRemarks - 串口备注管理纯逻辑测试
- * 测试：serialRemarks 缓存、loadSerialRemark 逻辑、saveSerialRemark 逻辑
- */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Mock window.storageApi
-const mockStorageApi = {
-  getComSettings: vi.fn(),
-  saveComSettings: vi.fn()
-}
+const { errorMessage, storageApi } = vi.hoisted(() => ({
+  errorMessage: vi.fn(),
+  storageApi: {
+    getComSettings: vi.fn(),
+    saveComSettings: vi.fn()
+  }
+}))
 
-vi.stubGlobal('window', {
-  storageApi: mockStorageApi
-})
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => key }) }))
+vi.mock('element-plus', () => ({ ElMessage: { error: errorMessage } }))
+vi.stubGlobal('window', { storageApi })
 
-describe('useSerialRemarks - pure logic', () => {
+import { useSerialRemarks } from '../../src/renderer/src/features/connections/useSerialRemarks'
+
+describe('useSerialRemarks', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    storageApi.getComSettings.mockResolvedValue({})
+    storageApi.saveComSettings.mockResolvedValue(true)
   })
 
-  describe('serialRemarks caching', () => {
-    it('should return cached remark without calling API', () => {
-      const cache: Record<string, string> = { 'COM1': 'My Device' }
-      const comName = 'COM1'
-      expect(cache[comName]).toBe('My Device')
-    })
+  it('caches a successfully loaded empty remark', async () => {
+    const remarks = useSerialRemarks({})
 
-    it('should return empty string for uncached port', () => {
-      const cache: Record<string, string> = {}
-      const result = cache['COM99'] || ''
-      expect(result).toBe('')
-    })
+    await expect(remarks.loadSerialRemark('COM1')).resolves.toBe('')
+    await expect(remarks.loadSerialRemark('COM1')).resolves.toBe('')
+
+    expect(storageApi.getComSettings).toHaveBeenCalledTimes(1)
+    expect(Object.hasOwn(remarks.serialRemarks, 'COM1')).toBe(true)
   })
 
-  describe('remark value logic', () => {
-    it('should store remark in cache', () => {
-      const serialRemarks: Record<string, string> = {}
-      const comName = 'COM1'
-      const remark = 'Test Device'
-      serialRemarks[comName] = remark
-      expect(serialRemarks[comName]).toBe('Test Device')
-    })
+  it('opens a remark dialog from the terminal remark without reloading storage', async () => {
+    const remarks = useSerialRemarks({ terminal: { getRemark: () => 'from terminal' } })
 
-    it('should overwrite existing remark', () => {
-      const serialRemarks: Record<string, string> = { 'COM1': 'Old Name' }
-      serialRemarks['COM1'] = 'New Name'
-      expect(serialRemarks['COM1']).toBe('New Name')
-    })
+    await remarks.openRemarkDialog({ id: 'terminal', comName: 'COM1' })
 
-    it('should handle empty remark', () => {
-      const serialRemarks: Record<string, string> = {}
-      serialRemarks['COM1'] = ''
-      expect(serialRemarks['COM1']).toBe('')
-    })
+    expect(remarks.editingRemarkComName.value).toBe('COM1')
+    expect(remarks.editingRemark.value).toBe('from terminal')
+    expect(remarks.showRemarkDialog.value).toBe(true)
+    expect(storageApi.getComSettings).not.toHaveBeenCalled()
   })
 
-  describe('settings merge on save', () => {
-    it('should merge remark with existing settings', async () => {
-      mockStorageApi.getComSettings.mockResolvedValue({
-        baudRate: 9600,
-        dataBits: 8,
-        stopBits: 1,
-        remark: 'Old'
-      })
-      mockStorageApi.saveComSettings.mockResolvedValue(true)
+  it('loads all remarks and ignores an individual storage failure', async () => {
+    storageApi.getComSettings
+      .mockResolvedValueOnce({ remark: 'one' })
+      .mockRejectedValueOnce(new Error('unavailable'))
 
-      const currentSettings = await mockStorageApi.getComSettings('COM1')
-      const newSettings = { ...currentSettings, remark: 'New Remark' }
+    const remarks = useSerialRemarks({})
+    await remarks.loadAllSerialRemarks([{ path: 'COM1' }, { path: 'COM2' }])
 
-      expect(newSettings.baudRate).toBe(9600)
-      expect(newSettings.dataBits).toBe(8)
-      expect(newSettings.remark).toBe('New Remark')
-    })
-
-    it('should handle null existing settings', async () => {
-      mockStorageApi.getComSettings.mockResolvedValue(null)
-      const currentSettings = await mockStorageApi.getComSettings('COM1')
-      const newSettings = { ...(currentSettings || {}), remark: 'Fresh Remark' }
-      expect(newSettings.remark).toBe('Fresh Remark')
-    })
+    expect(remarks.serialRemarks).toMatchObject({ COM1: 'one' })
+    expect(Object.hasOwn(remarks.serialRemarks, 'COM2')).toBe(false)
   })
 
-  describe('API error handling', () => {
-    it('should return empty string on API error', async () => {
-      mockStorageApi.getComSettings.mockRejectedValue(new Error('API error'))
-      try {
-        await mockStorageApi.getComSettings('COM1')
-      } catch {
-        // Expected - error handled gracefully
-        expect(true).toBe(true)
-      }
-    })
+  it('does not let a slow first port overwrite a quickly opened second port', async () => {
+    let resolveFirst: (value: unknown) => void = () => {}
+    storageApi.getComSettings
+      .mockImplementationOnce(() => new Promise(resolve => { resolveFirst = resolve }))
+      .mockResolvedValueOnce({ remark: 'second' })
+    const remarks = useSerialRemarks({})
+
+    const first = remarks.openSerialPortRemark('COM1')
+    const second = remarks.openSerialPortRemark('COM2')
+    await second
+    resolveFirst({ remark: 'first' })
+    await first
+
+    expect(remarks.editingRemarkComName.value).toBe('COM2')
+    expect(remarks.editingRemark.value).toBe('second')
+  })
+
+  it('saves by comName and updates every open terminal for that port', async () => {
+    storageApi.getComSettings.mockResolvedValue({ baudRate: 115200, remark: 'old' })
+    const com1First = { getComName: () => 'COM1', setRemark: vi.fn() }
+    const com1Second = { getComName: () => 'COM1', setRemark: vi.fn() }
+    const com2 = { getComName: () => 'COM2', setRemark: vi.fn() }
+    const remarks = useSerialRemarks({ staleTab: com2, first: com1First, second: com1Second })
+    remarks.editingRemarkComName.value = 'COM1'
+    remarks.editingRemark.value = 'device'
+    remarks.showRemarkDialog.value = true
+
+    await remarks.saveSerialRemark({ id: 'staleTab', comName: 'COM2' })
+
+    expect(storageApi.saveComSettings).toHaveBeenCalledWith('COM1', { baudRate: 115200, remark: 'device' })
+    expect(com1First.setRemark).toHaveBeenCalledWith('device')
+    expect(com1Second.setRemark).toHaveBeenCalledWith('device')
+    expect(com2.setRemark).not.toHaveBeenCalled()
+    expect(remarks.serialRemarks.COM1).toBe('device')
+    expect(remarks.showRemarkDialog.value).toBe(false)
+  })
+
+  it.each([
+    ['a rejected save', () => storageApi.saveComSettings.mockRejectedValue(new Error('failed'))],
+    ['a false save result', () => storageApi.saveComSettings.mockResolvedValue(false)]
+  ])('keeps cache and terminals unchanged after %s', async (_description, failSave) => {
+    failSave()
+    const terminal = { getComName: () => 'COM1', setRemark: vi.fn() }
+    const remarks = useSerialRemarks({ terminal })
+    remarks.serialRemarks.COM1 = 'old'
+    remarks.editingRemarkComName.value = 'COM1'
+    remarks.editingRemark.value = 'new'
+    remarks.showRemarkDialog.value = true
+
+    await remarks.saveSerialRemark()
+
+    expect(remarks.serialRemarks.COM1).toBe('old')
+    expect(terminal.setRemark).not.toHaveBeenCalled()
+    expect(remarks.showRemarkDialog.value).toBe(true)
+    expect(errorMessage).toHaveBeenCalledWith('dialog.remarkSaveFailed')
   })
 })


### PR DESCRIPTION
## 问题

1. **备注弹框竞态**：打开备注编辑框时需要异步读取串口设置，快速切换选项卡或对不同串口连续操作时，后发起的请求可能被先返回的旧请求覆盖，导致编辑框显示错误的备注
2. **缓存误判**：已缓存的空备注（`''`）被当作未缓存，每次打开都重复查询存储
3. **编辑入口受限**：只能对左侧已连接的选项卡编辑备注，串口列表里未连接的串口无法直接编辑

## 方案

- `useSerialRemarks` 引入 `openRequestId`：每次打开请求递增序号，仅最新请求的结果生效
- 缓存判断改用 `Object.hasOwn`，区分「未缓存」与「已缓存空备注」
- 新增 `openSerialPortRemark`：串口列表项右键菜单直接打开备注编辑
- 保存流程按 `editingRemarkComName` 定位，通过终端暴露的 `getComName`/`setRemark` 同步刷新所有已打开终端的备注显示（不再依赖右击的选项卡上下文）

## 测试

- 重写 `useSerialRemarks` 单元测试（182 行），覆盖竞态、缓存、保存同步等场景
- 全量单测 1224 个通过，typecheck 通过

---
> 本 PR 由 OpenCode (kimi-k3) 辅助整理与验证。