### PR TITLE
fix: 窗口最大化状态改用类型化 IPC 通知

### DIFF
--- a/src/main/ipc/IpcMain.ts
+++ b/src/main/ipc/IpcMain.ts
@@ -9,6 +9,7 @@ import SettingsStorage from '../storage/SettingsStorage'
 import BackupManager from '../utils/BackupManager'
 import fs from 'fs'
 import path from 'path'
+import { WINDOW_IPC_CHANNELS } from '../../shared/ipc/window'
 
 (app as any).isQuitting = false
 let isQuitting = false
@@ -74,18 +75,20 @@ export default class IpcMain {
         return { action: 'deny' }
       })
 
-      // 监听窗口最大化状态变化
-      mainWindow.on('maximize', () => {
-        mainWindow.webContents.executeJavaScript(
-          'window.dispatchEvent(new Event("window-maximized"))'
-        )
-      })
-
-      mainWindow.on('unmaximize', () => {
-        mainWindow.webContents.executeJavaScript(
-          'window.dispatchEvent(new Event("window-unmaximized"))'
-        )
-      })
+      // 监听窗口最大化状态变化（多事件兜底，兼容 Ubuntu 24 等 Linux 窗口管理器）
+      // 仅在状态真正变化时才通知渲染进程，避免 resize 事件风暴期间频繁 IPC。
+      let lastMaximized: boolean | null = null
+      const dispatchMaximizeState = () => {
+        const maximized = mainWindow.isMaximized()
+        if (maximized === lastMaximized) return
+        lastMaximized = maximized
+        if (mainWindow.isDestroyed()) return
+        mainWindow.webContents.send(WINDOW_IPC_CHANNELS.maximizedChanged, maximized)
+      }
+      mainWindow.on('maximize', dispatchMaximizeState)
+      mainWindow.on('unmaximize', dispatchMaximizeState)
+      // resize 事件兜底：某些 Linux 桌面环境（如 GNOME on Ubuntu 24）可能不触发 unmaximize
+      mainWindow.on('resize', dispatchMaximizeState)
 
       // 监听窗口关闭事件
       mainWindow.on('close', (event) => {

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -105,6 +105,7 @@ declare global {
       getWindowState: () => Promise<boolean>
       getAppVersion: () => Promise<string>
       toggleFullscreenWindow: () => Promise<void>
+      onMaximizedChanged: (callback: (maximized: boolean) => void) => () => void
     }
     toolApi: {
       openDevtools: () => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -121,7 +121,12 @@ contextBridge.exposeInMainWorld('windowApi', {
   closeWindow: () => ipcRenderer.invoke(WINDOW_IPC_CHANNELS.close),
   getWindowState: () => ipcRenderer.invoke(WINDOW_IPC_CHANNELS.getMaximized),
   getAppVersion: () => ipcRenderer.invoke(WINDOW_IPC_CHANNELS.getAppVersion),
-  toggleFullscreenWindow: () => ipcRenderer.invoke(WINDOW_IPC_CHANNELS.toggleFullscreen)
+  toggleFullscreenWindow: () => ipcRenderer.invoke(WINDOW_IPC_CHANNELS.toggleFullscreen),
+  onMaximizedChanged: (callback: (maximized: boolean) => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, maximized: boolean) => callback(maximized)
+    ipcRenderer.on(WINDOW_IPC_CHANNELS.maximizedChanged, listener)
+    return () => ipcRenderer.removeListener(WINDOW_IPC_CHANNELS.maximizedChanged, listener)
+  }
 })
 
 contextBridge.exposeInMainWorld('toolApi', {

--- a/src/renderer/src/components/CustomTitleBar.vue
+++ b/src/renderer/src/components/CustomTitleBar.vue
@@ -299,8 +299,7 @@ const props = defineProps({
   }
 })
 
-const handleWindowMaximized = () => (isMaximized.value = true)
-const handleWindowUnmaximized = () => (isMaximized.value = false)
+let removeMaximizedListener: (() => void) | undefined
 const minimizeWindow = () => window.windowApi.minimizeWindow()
 const maximizeWindow = () => window.windowApi.maximizeWindow()
 const closeWindow = () => window.windowApi.closeWindow()
@@ -582,15 +581,13 @@ watch(() => props.currentFont, (newFont) => {
 
 onMounted(async () => {
   window.windowApi.getWindowState().then((state) => (isMaximized.value = state))
-  window.addEventListener('window-maximized', handleWindowMaximized)
-  window.addEventListener('window-unmaximized', handleWindowUnmaximized)
+  removeMaximizedListener = window.windowApi.onMaximizedChanged((maximized) => (isMaximized.value = maximized))
   // 点击其他地方关闭菜单
   document.addEventListener('click', handleClickOutside)
 })
 
 onUnmounted(() => {
-  window.removeEventListener('window-maximized', handleWindowMaximized)
-  window.removeEventListener('window-unmaximized', handleWindowUnmaximized)
+  removeMaximizedListener?.()
   document.removeEventListener('click', handleClickOutside)
 })
 

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -91,6 +91,7 @@ interface WindowApi {
   getWindowState: () => Promise<any>
   getAppVersion: () => Promise<string>
   toggleFullscreenWindow: () => Promise<void>
+  onMaximizedChanged: (callback: (maximized: boolean) => void) => () => void
 }
 
 declare global {

--- a/src/shared/ipc/window.ts
+++ b/src/shared/ipc/window.ts
@@ -5,7 +5,8 @@ export const WINDOW_IPC_CHANNELS = {
   getMaximized: 'get-window-state',
   toggleMaximize: 'maximize-window',
   getAppVersion: 'get-app-version',
-  toggleFullscreen: 'toggle-fullscreen-window'
+  toggleFullscreen: 'toggle-fullscreen-window',
+  maximizedChanged: 'window-maximized-changed'
 } as const
 
 export type WindowIpcChannel = (typeof WINDOW_IPC_CHANNELS)[keyof typeof WINDOW_IPC_CHANNELS]

--- a/tests/unit/IpcMain.test.ts
+++ b/tests/unit/IpcMain.test.ts
@@ -4,7 +4,8 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { mockDialogHandlers } = vi.hoisted(() => ({
+const { mockBrowserWindows, mockDialogHandlers } = vi.hoisted(() => ({
+  mockBrowserWindows: [] as any[],
   mockDialogHandlers: new Map<string, Function>()
 }))
 
@@ -29,18 +30,22 @@ vi.mock('electron', () => ({
     static getFocusedWindow() { return null }
     static getAllWindows() { return [] }
     constructor() {
-      // mock instance methods
+      const events = new Map<string, Function>()
       Object.assign(this, {
+        events,
         loadFile: vi.fn(),
         loadURL: vi.fn(),
         hide: vi.fn(),
-        on: vi.fn(),
+        on: vi.fn((event: string, handler: Function) => events.set(event, handler)),
+        isMaximized: vi.fn(() => false),
+        isDestroyed: vi.fn(() => false),
         webContents: {
           on: vi.fn(),
           setWindowOpenHandler: vi.fn(),
-          executeJavaScript: vi.fn()
+          send: vi.fn()
         }
       })
+      mockBrowserWindows.push(this)
     }
   },
   shell: { openExternal: vi.fn() },
@@ -120,6 +125,7 @@ describe('IpcMain', () => {
     ;(IpcMain as any).sInstance = null
     ipcMainInst = IpcMain.getInstance()
     mockDialogHandlers.clear()
+    mockBrowserWindows.length = 0
   })
 
   describe('getInstance', () => {
@@ -179,6 +185,35 @@ describe('IpcMain', () => {
     it('should call checkForUpdates without error', async () => {
       ipcMainInst.init({ flush: vi.fn() }, {})
       await expect(mockDialogHandlers.get('check-for-updates')!()).resolves.toBeUndefined()
+    })
+  })
+
+  describe('window maximized state notifications', () => {
+    it('uses typed IPC and de-duplicates unchanged resize state', async () => {
+      ipcMainInst.init({ flush: vi.fn() }, {})
+      await vi.waitFor(() => expect(mockBrowserWindows).toHaveLength(1))
+      const window = mockBrowserWindows[0]
+
+      window.events.get('resize')!()
+      window.events.get('resize')!()
+
+      expect(window.webContents.send).toHaveBeenCalledTimes(1)
+      expect(window.webContents.send).toHaveBeenCalledWith('window-maximized-changed', false)
+
+      window.isMaximized.mockReturnValue(true)
+      window.events.get('maximize')!()
+      expect(window.webContents.send).toHaveBeenLastCalledWith('window-maximized-changed', true)
+    })
+
+    it('does not send after the window is destroyed', async () => {
+      ipcMainInst.init({ flush: vi.fn() }, {})
+      await vi.waitFor(() => expect(mockBrowserWindows).toHaveLength(1))
+      const window = mockBrowserWindows[0]
+      window.isDestroyed.mockReturnValue(true)
+
+      window.events.get('resize')!()
+
+      expect(window.webContents.send).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## 问题

主进程目前通过 `webContents.executeJavaScript` 注入 `window.dispatchEvent` 通知渲染进程最大化状态变化，存在问题：

1. resize 事件风暴期间可能频繁执行 JS 注入，造成窗口卡顿
2. 某些 Linux 桌面环境（如 GNOME on Ubuntu 24）不触发 `unmaximize`，标题栏状态与实际不符
3. 窗口销毁后仍可能注入执行，产生无意义调用

## 方案

- 改用类型化 IPC：`webContents.send('window-maximized-changed', maximized)`，渲染进程通过 `windowApi.onMaximizedChanged` 订阅并在卸载时移除
- 状态去重：仅在 `isMaximized()` 结果真正变化时通知
- 增加 `resize` 事件兜底，兼容不触发 `unmaximize` 的 Linux 窗口管理器
- 窗口已销毁（`isDestroyed`）时跳过发送

## 测试

- 新增 IpcMain 最大化通知单元测试：重复 resize 去重、销毁后停发
- 全量单测 1227 个通过，typecheck 通过

---
> 本 PR 由 OpenCode (kimi-k3) 辅助整理与验证。